### PR TITLE
Allow schema v2 deployment baselines

### DIFF
--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -343,6 +343,37 @@ class ContentSyncTests(unittest.TestCase):
         for change in plan.record_changes:
             self.assertEqual(len(change["expectedOldStates"]), 2)
 
+    def test_incremental_plan_accepts_schema_v2_only_in_historical_base(self) -> None:
+        value = json.loads(self.transcript_path.read_text(encoding="utf-8"))
+        value["schemaVersion"] = 2
+        value["revisions"][0]["sha256"] = SHA
+        self.write_json(self.transcript_path, value, indent=2)
+        self.commit("legacy v2 base")
+        legacy_base = self.git("rev-parse", "HEAD").strip()
+
+        self.write_transcript("corrected text", "official")
+        self.commit("migrate and correct transcript")
+
+        plan = ContentSyncPlanner(
+            self.repo, MemoryStore(self.published()), cdn_base_url=CDN
+        ).build(base=legacy_base)
+
+        self.assertTrue(plan.deployable, plan.to_markdown())
+        self.assertEqual(plan.conflict_count, 0)
+        self.assertEqual(len(plan.record_changes), 2)
+        self.assertTrue(all(change["status"] == "update" for change in plan.record_changes))
+
+    def test_current_worktree_still_rejects_schema_v2(self) -> None:
+        value = json.loads(self.transcript_path.read_text(encoding="utf-8"))
+        value["schemaVersion"] = 2
+        value["revisions"][0]["sha256"] = SHA
+        self.write_json(self.transcript_path, value, indent=2)
+
+        report = validate_repository(self.repo)
+
+        self.assertFalse(report.valid)
+        self.assertTrue(any("schemaVersion must be 3" in item for item in report.errors))
+
     def test_formatting_only_direct_config_change_is_source_noop(self) -> None:
         path = self.repo / "config" / "deadlock" / "versions" / "v1" / "character-names.json"
         value = {"schemaVersion": 1, "game": "deadlock", "names": {"hero": "Hero"}}

--- a/tools/content_sync.py
+++ b/tools/content_sync.py
@@ -737,10 +737,15 @@ def _transcript_files(root: Path) -> Iterator[Path]:
 def _document_states(
     document: dict[str, Any] | None,
     context: str,
+    *,
+    allow_legacy_v2: bool = False,
 ) -> dict[str, TranscriptState]:
     if document is None:
         return {}
-    if document.get("schemaVersion") != TRANSCRIPT_SCHEMA_VERSION:
+    schema_version = document.get("schemaVersion")
+    if schema_version != TRANSCRIPT_SCHEMA_VERSION and not (
+        allow_legacy_v2 and schema_version == 2
+    ):
         raise ContentSyncError(
             f"Transcript schemaVersion must be {TRANSCRIPT_SCHEMA_VERSION}: {context}"
         )
@@ -770,6 +775,11 @@ def _document_states(
         if model is not None and (not isinstance(model, str) or not model):
             raise ContentSyncError(f"{context} revisions[{index}] has invalid model")
         hashes = revision.get("sha256")
+        if schema_version == 2:
+            if isinstance(hashes, str):
+                hashes = [hashes]
+            elif hashes is None:
+                hashes = []
         if not isinstance(hashes, list):
             raise ContentSyncError(f"{context} revisions[{index}] SHA-256 must be an array")
         for sha in hashes:
@@ -1338,7 +1348,11 @@ class ContentSyncPlanner:
                 old_document = read_git_json(self.repo, base or "", path) if base else None
                 new_document = read_worktree_json(self.repo, path)
                 try:
-                    old_states = _document_states(old_document, f"{base}:{path}")
+                    old_states = _document_states(
+                        old_document,
+                        f"{base}:{path}",
+                        allow_legacy_v2=True,
+                    )
                     new_states = _document_states(new_document, path)
                 except ContentSyncError as exc:
                     plan.errors.append(str(exc))


### PR DESCRIPTION
## Root cause
The deployment cursor still points to commit 56fbbdce1e18c5d736afa1530392e1e981c6605e, whose transcript files use schema v2. Incremental planning validates both the current target and the historical base with the v3-only parser, so deployment stops before calculating changes even though current main is fully schema v3.

## Fix
- allow schema-v2 scalar or null hashes only while reading a historical incremental base
- normalize those legacy hashes in memory for state comparison
- continue requiring schema v3 for the checked-out target and repository validation
- add regression tests for both the accepted historical baseline and rejected current v2 content

## Validation
- python -m unittest discover -s tests -v (59 tests)
- python -m tools.content_sync_cli validate --repo . (98,944 transcript files; valid)
- targeted incremental-plan regression reproducing the v2-base/v3-target transition
- git diff --check
- GitHub Content sync plan check passes

This PR does not modify transcript data or deploy CDN content directly.