### PR TITLE
Fix obviously wrong transcripts

### DIFF
--- a/transcripts/announcer/female_patron/patron_female_ally_tengu_start_01_alt_01.mp3.json
+++ b/transcripts/announcer/female_patron/patron_female_ally_tengu_start_01_alt_01.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "a6e9e3b4eda6b70933d0f378f72f149530aad18729469eee5e44aad8479d7bd3",
         "d4336e3bea8f53ff981acc17ee7accaa87b5b3e13c973ed71dfcf60006e30b93"
-      ],
-      "text": "You are lost, Ivy. Directionless. But I see beyond what your heart wants. I see what you need. Summon me.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "a6e9e3b4eda6b70933d0f378f72f149530aad18729469eee5e44aad8479d7bd3"
       ],
       "text": "You are lost, Ivy. Directionless. But I see beyond what your heart wants. I see what you need. Summon me.",
       "source": "generated",

--- a/transcripts/announcer/female_patron/patron_female_ally_tengu_start_01_alt_01.mp3.json
+++ b/transcripts/announcer/female_patron/patron_female_ally_tengu_start_01_alt_01.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "d4336e3bea8f53ff981acc17ee7accaa87b5b3e13c973ed71dfcf60006e30b93"
       ],
-      "text": "You lost, Tyree. Directionless. But I see beyond what your heart wants. I see what you need. Summon me.",
+      "text": "You are lost, Ivy. Directionless. But I see beyond what your heart wants. I see what you need. Summon me.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "a6e9e3b4eda6b70933d0f378f72f149530aad18729469eee5e44aad8479d7bd3"
       ],
-      "text": "You lost Ivy, directionless. But I see beyond what your heart wants. I see what you need. Summon me.",
+      "text": "You are lost, Ivy. Directionless. But I see beyond what your heart wants. I see what you need. Summon me.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/announcer/female_patron/patron_female_ally_wraith_start_04.mp3.json
+++ b/transcripts/announcer/female_patron/patron_female_ally_wraith_start_04.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "07095b0f9ffbfe868f489d9c73c726461636941289bb55ccc56e4757d763de7b"
-      ],
-      "text": "You've donned your father's chains, Wraith. I hope it works out better for you than it did for him.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "07095b0f9ffbfe868f489d9c73c726461636941289bb55ccc56e4757d763de7b",
         "db2c006dd1605475aaf122af94a0c674f60f3800d2756f6e7fc04257ea739480"
       ],
       "text": "You've donned your father's chains, Wraith. I hope it works out better for you than it did for him.",
@@ -22,7 +15,7 @@
       "sha256": [
         "694118cbd93277e199b820239b35977de4094b33dccb5a2fc4fe09079bc995ea"
       ],
-      "text": "You live your life one step ahead of death… let The Archmother provide the security you seek",
+      "text": "You live your life one step ahead of deathâ€¦ let The Archmother provide the security you seek",
       "source": "official"
     }
   ]

--- a/transcripts/announcer/female_patron/patron_female_ally_wraith_start_04.mp3.json
+++ b/transcripts/announcer/female_patron/patron_female_ally_wraith_start_04.mp3.json
@@ -15,7 +15,7 @@
       "sha256": [
         "694118cbd93277e199b820239b35977de4094b33dccb5a2fc4fe09079bc995ea"
       ],
-      "text": "You live your life one step ahead of deathâ€¦ let The Archmother provide the security you seek",
+      "text": "You live your life one step ahead of death... let The Archmother provide the security you seek",
       "source": "official"
     }
   ]

--- a/transcripts/announcer/female_patron/patron_female_ally_wraith_start_04.mp3.json
+++ b/transcripts/announcer/female_patron/patron_female_ally_wraith_start_04.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "07095b0f9ffbfe868f489d9c73c726461636941289bb55ccc56e4757d763de7b"
       ],
-      "text": "",
+      "text": "You've donned your father's chains, Wraith. I hope it works out better for you than it did for him.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "db2c006dd1605475aaf122af94a0c674f60f3800d2756f6e7fc04257ea739480"
       ],
-      "text": "",
+      "text": "You've donned your father's chains, Wraith. I hope it works out better for you than it did for him.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/announcer/female_patron/patron_female_ally_wraith_start_04.mp3.json
+++ b/transcripts/announcer/female_patron/patron_female_ally_wraith_start_04.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "07095b0f9ffbfe868f489d9c73c726461636941289bb55ccc56e4757d763de7b"
       ],
-      "text": "You've damned your father's king's wrath. I hope it works out better for you than it did for him.",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "db2c006dd1605475aaf122af94a0c674f60f3800d2756f6e7fc04257ea739480"
       ],
-      "text": "You've damned your father's chains, Wraith. I hope it works out better for you than it did for him.",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/atlas/abrams_enemy_krill_grabbed_02.mp3.json
+++ b/transcripts/atlas/abrams_enemy_krill_grabbed_02.mp3.json
@@ -4,23 +4,9 @@
   "revisions": [
     {
       "sha256": [
+        "0e95501b5de9d7b29a643f4e92f34774c0a4850b180c5720687690bf765a009f",
+        "36bc412c745325c28624bd2d1beb2fe2a713fa96010cb9413a87cfab9a7a8181",
         "d290bdf0518202955b291a909f7a2459f56c2d17da7b07a96a05c47045611ca1"
-      ],
-      "text": "Someone kill this moleman!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "36bc412c745325c28624bd2d1beb2fe2a713fa96010cb9413a87cfab9a7a8181"
-      ],
-      "text": "Someone kill this moleman!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "0e95501b5de9d7b29a643f4e92f34774c0a4850b180c5720687690bf765a009f"
       ],
       "text": "Someone kill this moleman!",
       "source": "generated",

--- a/transcripts/atlas/abrams_enemy_krill_grabbed_02.mp3.json
+++ b/transcripts/atlas/abrams_enemy_krill_grabbed_02.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "d290bdf0518202955b291a909f7a2459f56c2d17da7b07a96a05c47045611ca1"
       ],
-      "text": "Someone kill this moment.",
+      "text": "Someone kill this moleman!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "36bc412c745325c28624bd2d1beb2fe2a713fa96010cb9413a87cfab9a7a8181"
       ],
-      "text": "Someone kill this mo-man!",
+      "text": "Someone kill this moleman!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "0e95501b5de9d7b29a643f4e92f34774c0a4850b180c5720687690bf765a009f"
       ],
-      "text": "Someone kill this momen!",
+      "text": "Someone kill this moleman!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_ability1_almost_ready.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_ability1_almost_ready.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "0f727e1547b2103c45ced461445753174528447817591babd38e851cfd9e55c2"
       ],
-      "text": "This life is almost ready.",
+      "text": "Siphon Life's almost ready.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "8b72863d3bbe8331b98a605da1568fa023412d57a273c508ca020673bcafe991"
       ],
-      "text": "This life's is almost ready.",
+      "text": "Siphon Life's almost ready.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_ability1_almost_ready.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_ability1_almost_ready.mp3.json
@@ -12,14 +12,7 @@
     },
     {
       "sha256": [
-        "0f727e1547b2103c45ced461445753174528447817591babd38e851cfd9e55c2"
-      ],
-      "text": "Siphon Life's almost ready.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "0f727e1547b2103c45ced461445753174528447817591babd38e851cfd9e55c2",
         "8b72863d3bbe8331b98a605da1568fa023412d57a273c508ca020673bcafe991"
       ],
       "text": "Siphon Life's almost ready.",

--- a/transcripts/atlas/ping/abrams_ping_defend_orange_01.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_defend_orange_01.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "a578b3ed184fde245b9838cc419213ddd6e141d46ca173cf3cfb36db7116f1f8"
       ],
-      "text": "The Fen orange.",
+      "text": "Defend orange.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "df37a3eff4180a59b86f51b4aefce4979aa1c26428d551e88203c15c421b02be"
       ],
-      "text": "The Fend Orange.",
+      "text": "Defend orange.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_defend_orange_01.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_defend_orange_01.mp3.json
@@ -12,14 +12,7 @@
     },
     {
       "sha256": [
-        "a578b3ed184fde245b9838cc419213ddd6e141d46ca173cf3cfb36db7116f1f8"
-      ],
-      "text": "Defend orange.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "a578b3ed184fde245b9838cc419213ddd6e141d46ca173cf3cfb36db7116f1f8",
         "df37a3eff4180a59b86f51b4aefce4979aa1c26428d551e88203c15c421b02be"
       ],
       "text": "Defend orange.",

--- a/transcripts/atlas/ping/abrams_ping_grey_talon_in_mid.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_grey_talon_in_mid.mp3.json
@@ -7,7 +7,7 @@
         "29131e9606dc6f008aced2a4241e7d6546586c8726b966d851d491dca557799f",
         "81ddd0922f3c1777eae9e9c87cc660ada94588e7560f53bc23ab6d86247ce9ae"
       ],
-      "text": "Great talent in mid.",
+      "text": "Grey Talon's in mid.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_grey_talon_in_mid_1.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_grey_talon_in_mid_1.mp3.json
@@ -7,7 +7,7 @@
         "29131e9606dc6f008aced2a4241e7d6546586c8726b966d851d491dca557799f",
         "81ddd0922f3c1777eae9e9c87cc660ada94588e7560f53bc23ab6d86247ce9ae"
       ],
-      "text": "Great talent in mid.",
+      "text": "Grey Talon's in mid.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_haze_under_garage.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_haze_under_garage.mp3.json
@@ -4,23 +4,9 @@
   "revisions": [
     {
       "sha256": [
-        "51dbd0730ffbd65f227eb48cd4b3eb48ce5c38137efb5175bda8cfda6c45e5f1"
-      ],
-      "text": "Haze is under the garage.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "51dbd0730ffbd65f227eb48cd4b3eb48ce5c38137efb5175bda8cfda6c45e5f1",
+        "a9d2de491d5f074a17a556c4f9ea97e6283c5a1d20a280ce07bfb1c3cf89ed3d",
         "cd4735556b27fd1594a6d4cd936de57f11aa62f228ebf814f4c2d78fe383c288"
-      ],
-      "text": "Haze is under the garage.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "a9d2de491d5f074a17a556c4f9ea97e6283c5a1d20a280ce07bfb1c3cf89ed3d"
       ],
       "text": "Haze is under the garage.",
       "source": "generated",

--- a/transcripts/atlas/ping/abrams_ping_haze_under_garage.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_haze_under_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "51dbd0730ffbd65f227eb48cd4b3eb48ce5c38137efb5175bda8cfda6c45e5f1"
       ],
-      "text": "He's under the garage.",
+      "text": "Haze is under the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "cd4735556b27fd1594a6d4cd936de57f11aa62f228ebf814f4c2d78fe383c288"
       ],
-      "text": "Hey, he's under the garage.",
+      "text": "Haze is under the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "a9d2de491d5f074a17a556c4f9ea97e6283c5a1d20a280ce07bfb1c3cf89ed3d"
       ],
-      "text": "He is under the garage.",
+      "text": "Haze is under the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_orion_in_mid.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_orion_in_mid.mp3.json
@@ -4,16 +4,9 @@
   "revisions": [
     {
       "sha256": [
+        "00aef6f886b165c2182b176c9ffb867399cc64199fb851fc8a97c29e675351c2",
         "28cbbf7b2bd787ed4b0cb64bc805230b7472c40697d6156fdda47d5c28db7f66",
         "29131e9606dc6f008aced2a4241e7d6546586c8726b966d851d491dca557799f"
-      ],
-      "text": "Grey Talon's in mid.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "00aef6f886b165c2182b176c9ffb867399cc64199fb851fc8a97c29e675351c2"
       ],
       "text": "Grey Talon's in mid.",
       "source": "generated",

--- a/transcripts/atlas/ping/abrams_ping_orion_in_mid.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_orion_in_mid.mp3.json
@@ -7,7 +7,7 @@
         "28cbbf7b2bd787ed4b0cb64bc805230b7472c40697d6156fdda47d5c28db7f66",
         "29131e9606dc6f008aced2a4241e7d6546586c8726b966d851d491dca557799f"
       ],
-      "text": "Great talent in mid.",
+      "text": "Grey Talon's in mid.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -15,7 +15,7 @@
       "sha256": [
         "00aef6f886b165c2182b176c9ffb867399cc64199fb851fc8a97c29e675351c2"
       ],
-      "text": "Great talents in mid.",
+      "text": "Grey Talon's in mid.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_orion_in_mid_1.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_orion_in_mid_1.mp3.json
@@ -7,7 +7,7 @@
         "29131e9606dc6f008aced2a4241e7d6546586c8726b966d851d491dca557799f",
         "81ddd0922f3c1777eae9e9c87cc660ada94588e7560f53bc23ab6d86247ce9ae"
       ],
-      "text": "Great talent in mid.",
+      "text": "Grey Talon's in mid.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_rutger_on_top_of_garage.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_rutger_on_top_of_garage.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "3037df27958878eefe78e96d159deb98b569b9ebe10ff1f4ab4e9e5cb4370049",
         "ba9d8cabf808b99b83fb3f515efcedc5b90df44b121d0ec0257aa7c75bbbc08a"
-      ],
-      "text": "Rutger's on top of the garage.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "3037df27958878eefe78e96d159deb98b569b9ebe10ff1f4ab4e9e5cb4370049"
       ],
       "text": "Rutger's on top of the garage.",
       "source": "generated",

--- a/transcripts/atlas/ping/abrams_ping_rutger_on_top_of_garage.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_rutger_on_top_of_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "ba9d8cabf808b99b83fb3f515efcedc5b90df44b121d0ec0257aa7c75bbbc08a"
       ],
-      "text": "Truckers on top of the garage.",
+      "text": "Rutger's on top of the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "3037df27958878eefe78e96d159deb98b569b9ebe10ff1f4ab4e9e5cb4370049"
       ],
-      "text": "Ruckers on top of the garage.",
+      "text": "Rutger's on top of the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_see_grey_talon_on_roof.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_see_grey_talon_on_roof.mp3.json
@@ -7,7 +7,7 @@
         "1c6d07b6ce25d9dc5ec8c7cd38d1caa93416c1d3bcae2289cddd3b2936c80bb3",
         "2b5306e92b45ab9f6328fda281f9a67d09f66e5485250c472fcb6fd65a96cbf6"
       ],
-      "text": "Great talent on the roof.",
+      "text": "Grey Talon's on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_see_grey_talon_on_roof_1.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_see_grey_talon_on_roof_1.mp3.json
@@ -7,7 +7,7 @@
         "1c6d07b6ce25d9dc5ec8c7cd38d1caa93416c1d3bcae2289cddd3b2936c80bb3",
         "2b5306e92b45ab9f6328fda281f9a67d09f66e5485250c472fcb6fd65a96cbf6"
       ],
-      "text": "Great talent on the roof.",
+      "text": "Grey Talon's on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_see_orion_on_roof.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_see_orion_on_roof.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "1c6d07b6ce25d9dc5ec8c7cd38d1caa93416c1d3bcae2289cddd3b2936c80bb3"
-      ],
-      "text": "Grey Talon's on the roof.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "1c6d07b6ce25d9dc5ec8c7cd38d1caa93416c1d3bcae2289cddd3b2936c80bb3",
         "cef298d5b141751383e55a2667258a7cd040610927f142496ffcdfc09df71736",
         "f5bfab6da1639dbd03f82346d5dff46033ea5d9afe4e40d09e795f736b888cfc"
       ],

--- a/transcripts/atlas/ping/abrams_ping_see_orion_on_roof.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_see_orion_on_roof.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "1c6d07b6ce25d9dc5ec8c7cd38d1caa93416c1d3bcae2289cddd3b2936c80bb3"
       ],
-      "text": "Great talent on the roof.",
+      "text": "Grey Talon's on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -15,7 +15,7 @@
         "cef298d5b141751383e55a2667258a7cd040610927f142496ffcdfc09df71736",
         "f5bfab6da1639dbd03f82346d5dff46033ea5d9afe4e40d09e795f736b888cfc"
       ],
-      "text": "Great talents on the roof.",
+      "text": "Grey Talon's on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_see_orion_on_roof_1.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_see_orion_on_roof_1.mp3.json
@@ -7,7 +7,7 @@
         "1c6d07b6ce25d9dc5ec8c7cd38d1caa93416c1d3bcae2289cddd3b2936c80bb3",
         "2b5306e92b45ab9f6328fda281f9a67d09f66e5485250c472fcb6fd65a96cbf6"
       ],
-      "text": "Great talent on the roof.",
+      "text": "Grey Talon's on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_stun_inferno_01.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_stun_inferno_01.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "dd2f246babfd924248072a6d69eff7610dcff0cab8f20be5ce97d871d2c54ed4"
       ],
-      "text": "Stun in furnace.",
+      "text": "Stun Infernus.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "2ed2bd0ac268ca5a7e2d23688dd7f1f1d312fea0d8cf4361757e28d6dd7d6712"
       ],
-      "text": "Sun in furnace.",
+      "text": "Stun Infernus.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_stun_inferno_01.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_stun_inferno_01.mp3.json
@@ -4,6 +4,7 @@
   "revisions": [
     {
       "sha256": [
+        "2ed2bd0ac268ca5a7e2d23688dd7f1f1d312fea0d8cf4361757e28d6dd7d6712",
         "dd2f246babfd924248072a6d69eff7610dcff0cab8f20be5ce97d871d2c54ed4"
       ],
       "text": "Stun Infernus.",
@@ -15,14 +16,6 @@
         "4db1d70c5924a03f4cb19744dc6ced7f8c260d08a60ee2a60775f8f92c2c0302"
       ],
       "text": "Sun Infernis.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "2ed2bd0ac268ca5a7e2d23688dd7f1f1d312fea0d8cf4361757e28d6dd7d6712"
-      ],
-      "text": "Stun Infernus.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_stun_inferno_01_1.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_stun_inferno_01_1.mp3.json
@@ -7,7 +7,7 @@
         "ba35f1dc6f74fbd0873a21517eb898a8ae0120efc0113bd6acea18bf451c778b",
         "dd2f246babfd924248072a6d69eff7610dcff0cab8f20be5ce97d871d2c54ed4"
       ],
-      "text": "Stun in furnace.",
+      "text": "Stun Infernus.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_stun_infernus_01.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_stun_infernus_01.mp3.json
@@ -7,7 +7,7 @@
         "ba35f1dc6f74fbd0873a21517eb898a8ae0120efc0113bd6acea18bf451c778b",
         "dd2f246babfd924248072a6d69eff7610dcff0cab8f20be5ce97d871d2c54ed4"
       ],
-      "text": "Stun in furnace.",
+      "text": "Stun Infernus.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_stun_infernus_01_1.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_stun_infernus_01_1.mp3.json
@@ -7,7 +7,7 @@
         "ba35f1dc6f74fbd0873a21517eb898a8ae0120efc0113bd6acea18bf451c778b",
         "dd2f246babfd924248072a6d69eff7610dcff0cab8f20be5ce97d871d2c54ed4"
       ],
-      "text": "Stun in furnace.",
+      "text": "Stun Infernus.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_warp_stone_almost_ready.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_warp_stone_almost_ready.mp3.json
@@ -4,16 +4,9 @@
   "revisions": [
     {
       "sha256": [
-        "d6876411461ac286b5a414f9d6e23717361d383a5cf3c019a10b5153e5aae0da"
-      ],
-      "text": "Warp Stone's almost ready.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
         "3064fa81fddd3ac3943d6a990aa751f485e079037c3d85181dd306a8d05b64b4",
-        "bee9a5f4d2f9facde42dc52d6596a14064a6a4237bc5ffaf8f763ed131882533"
+        "bee9a5f4d2f9facde42dc52d6596a14064a6a4237bc5ffaf8f763ed131882533",
+        "d6876411461ac286b5a414f9d6e23717361d383a5cf3c019a10b5153e5aae0da"
       ],
       "text": "Warp Stone's almost ready.",
       "source": "generated",

--- a/transcripts/atlas/ping/abrams_ping_warp_stone_almost_ready.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_warp_stone_almost_ready.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "d6876411461ac286b5a414f9d6e23717361d383a5cf3c019a10b5153e5aae0da"
       ],
-      "text": "Warfstones almost ready.",
+      "text": "Warp Stone's almost ready.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -15,7 +15,7 @@
         "3064fa81fddd3ac3943d6a990aa751f485e079037c3d85181dd306a8d05b64b4",
         "bee9a5f4d2f9facde42dc52d6596a14064a6a4237bc5ffaf8f763ed131882533"
       ],
-      "text": "Warstone's almost ready.",
+      "text": "Warp Stone's almost ready.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_warp_stone_almost_ready_1.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_warp_stone_almost_ready_1.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "3f845bf71c050fd179ea46951d38d127cf7d51d5af6d7af41e0824e784582b36",
         "d6876411461ac286b5a414f9d6e23717361d383a5cf3c019a10b5153e5aae0da"
-      ],
-      "text": "Warp Stone's almost ready.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "3f845bf71c050fd179ea46951d38d127cf7d51d5af6d7af41e0824e784582b36"
       ],
       "text": "Warp Stone's almost ready.",
       "source": "generated",

--- a/transcripts/atlas/ping/abrams_ping_warp_stone_almost_ready_1.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_warp_stone_almost_ready_1.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "d6876411461ac286b5a414f9d6e23717361d383a5cf3c019a10b5153e5aae0da"
       ],
-      "text": "Warfstones almost ready.",
+      "text": "Warp Stone's almost ready.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "3f845bf71c050fd179ea46951d38d127cf7d51d5af6d7af41e0824e784582b36"
       ],
-      "text": "Warftone's almost ready.",
+      "text": "Warp Stone's almost ready.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_wraith_almost_respawn.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_wraith_almost_respawn.mp3.json
@@ -4,23 +4,9 @@
   "revisions": [
     {
       "sha256": [
-        "4fdf60678483cd6ed54d6d77a9a5538fb4507b9d0565a9692449855aba20d853"
-      ],
-      "text": "Wraith is almost back.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "4fdf60678483cd6ed54d6d77a9a5538fb4507b9d0565a9692449855aba20d853",
+        "e3e46b4e776d8721dbafba5f311ce90355881c08d1c46e53b04477820eea086d",
         "efcd81e6dbec8ea98e4ed1a29573a8f63237ed8a902194ed9394e43546bbb11f"
-      ],
-      "text": "Wraith is almost back.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "e3e46b4e776d8721dbafba5f311ce90355881c08d1c46e53b04477820eea086d"
       ],
       "text": "Wraith is almost back.",
       "source": "generated",

--- a/transcripts/atlas/ping/abrams_ping_wraith_almost_respawn.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_wraith_almost_respawn.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "efcd81e6dbec8ea98e4ed1a29573a8f63237ed8a902194ed9394e43546bbb11f"
       ],
-      "text": "Grace is almost back.",
+      "text": "Wraith is almost back.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "e3e46b4e776d8721dbafba5f311ce90355881c08d1c46e53b04477820eea086d"
       ],
-      "text": "Race is almost back.",
+      "text": "Wraith is almost back.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/atlas/ping/abrams_ping_wraith_on_top_of_garage.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_wraith_on_top_of_garage.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "381162e66259c9f8c8756c105f4169b385d803cd7664d7017e8acea9522e0db6"
-      ],
-      "text": "Wraith's on top of the garage.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "381162e66259c9f8c8756c105f4169b385d803cd7664d7017e8acea9522e0db6",
         "7747aa88572519efd0c0c2b685c4158c20a853f824a60bccabf0812f453d7971",
         "e07841024224276aa1acbddabc7d5328b0cc3ca1cb18b438959768e4d008d232"
       ],

--- a/transcripts/atlas/ping/abrams_ping_wraith_on_top_of_garage.mp3.json
+++ b/transcripts/atlas/ping/abrams_ping_wraith_on_top_of_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "381162e66259c9f8c8756c105f4169b385d803cd7664d7017e8acea9522e0db6"
       ],
-      "text": "Grave on top of the garage.",
+      "text": "Wraith's on top of the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -15,7 +15,7 @@
         "7747aa88572519efd0c0c2b685c4158c20a853f824a60bccabf0812f453d7971",
         "e07841024224276aa1acbddabc7d5328b0cc3ca1cb18b438959768e4d008d232"
       ],
-      "text": "Graves on top of the garage.",
+      "text": "Wraith's on top of the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/book/oathkeeper/vn_geist_scene05b_27.mp3.json
+++ b/transcripts/book/oathkeeper/vn_geist_scene05b_27.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "1d455254ada50e3d113cf1b45d5bfb337326fac05aeeace5d3b3b417b232560f"
       ],
-      "text": "I would think that you'd be happy that the Oskipa situation has... evolved.",
+      "text": "I would think that you'd be happy that the Oathkeeper situation has... evolved.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "fe6359688a53ca3a7c9aaa56a89e8cedf4f116b69e5f1349462ee0ea788bc5c5"
       ],
-      "text": "I would think that you'd be happy that the Oskaba situation has evolved.",
+      "text": "I would think that you'd be happy that the Oathkeeper situation has evolved.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/book/oathkeeper/vn_geist_scene05b_27.mp3.json
+++ b/transcripts/book/oathkeeper/vn_geist_scene05b_27.mp3.json
@@ -4,17 +4,10 @@
   "revisions": [
     {
       "sha256": [
-        "1d455254ada50e3d113cf1b45d5bfb337326fac05aeeace5d3b3b417b232560f"
-      ],
-      "text": "I would think that you'd be happy that the Oathkeeper situation has... evolved.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "1d455254ada50e3d113cf1b45d5bfb337326fac05aeeace5d3b3b417b232560f",
         "fe6359688a53ca3a7c9aaa56a89e8cedf4f116b69e5f1349462ee0ea788bc5c5"
       ],
-      "text": "I would think that you'd be happy that the Oathkeeper situation has evolved.",
+      "text": "I would think that you'd be happy that the Oathkeeper situation has... evolved.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/butcher/rr_test_21_near_miss_04.mp3.json
+++ b/transcripts/butcher/rr_test_21_near_miss_04.mp3.json
@@ -7,7 +7,7 @@
         "6f032dea9cc044b6aad754c42f6f630c3488103eb6654286c98b1b443879a726",
         "bf52752dd117ee8dd97a270415481dfceacaf68ed42f93db94844040f54fa6a3"
       ],
-      "text": "I'm getting next time.",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -15,7 +15,7 @@
       "sha256": [
         "9ea7d30c47ac60f03d68329da00879a6b12b5fa8ea2caf74a6773443c6a4aa72"
       ],
-      "text": "I'm gettin' next time.",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/butcher/rr_test_21_near_miss_04.mp3.json
+++ b/transcripts/butcher/rr_test_21_near_miss_04.mp3.json
@@ -5,15 +5,8 @@
     {
       "sha256": [
         "6f032dea9cc044b6aad754c42f6f630c3488103eb6654286c98b1b443879a726",
+        "9ea7d30c47ac60f03d68329da00879a6b12b5fa8ea2caf74a6773443c6a4aa72",
         "bf52752dd117ee8dd97a270415481dfceacaf68ed42f93db94844040f54fa6a3"
-      ],
-      "text": "",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "9ea7d30c47ac60f03d68329da00879a6b12b5fa8ea2caf74a6773443c6a4aa72"
       ],
       "text": "",
       "source": "generated",

--- a/transcripts/butcher/rr_test_21_ping_ability2_not_ready.mp3.json
+++ b/transcripts/butcher/rr_test_21_ping_ability2_not_ready.mp3.json
@@ -4,16 +4,9 @@
   "revisions": [
     {
       "sha256": [
+        "42f789d60ae1637b7ad6eea526d756c2a97a1a226e3bd5bc1cfd33d58f7e95c2",
         "6a05c270228d5cf40525798ab0f5dfdceebadcda157d7ac847485968952814ed",
         "daca363301e1ceb4ae414e23750a87b24d8e0c2663aa8ded2d6f5debb1fc49ee"
-      ],
-      "text": "",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "42f789d60ae1637b7ad6eea526d756c2a97a1a226e3bd5bc1cfd33d58f7e95c2"
       ],
       "text": "",
       "source": "generated",

--- a/transcripts/butcher/rr_test_21_ping_ability2_not_ready.mp3.json
+++ b/transcripts/butcher/rr_test_21_ping_ability2_not_ready.mp3.json
@@ -7,7 +7,7 @@
         "6a05c270228d5cf40525798ab0f5dfdceebadcda157d7ac847485968952814ed",
         "daca363301e1ceb4ae414e23750a87b24d8e0c2663aa8ded2d6f5debb1fc49ee"
       ],
-      "text": "As it sprays on cooldown.",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -15,7 +15,7 @@
       "sha256": [
         "42f789d60ae1637b7ad6eea526d756c2a97a1a226e3bd5bc1cfd33d58f7e95c2"
       ],
-      "text": "As it's sprays on cooldown.",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/butcher/rr_test_21_ping_tempest_back_01.mp3.json
+++ b/transcripts/butcher/rr_test_21_ping_tempest_back_01.mp3.json
@@ -4,23 +4,9 @@
   "revisions": [
     {
       "sha256": [
+        "93ea9a8b9ec6efc11a6714ecbda4f71bc9c228ed847d7fab3180866971602cfc",
+        "b408a6643039e5b1b79612ba924ce440dc42bd0a6568ebe91097b6d1c33ae915",
         "c93968bd6ab4cec59269306d4135ede0d06b5ba0162c3a7e6f743f4ba95e3586"
-      ],
-      "text": "Tempest, get back!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "b408a6643039e5b1b79612ba924ce440dc42bd0a6568ebe91097b6d1c33ae915"
-      ],
-      "text": "Tempest, get back!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "93ea9a8b9ec6efc11a6714ecbda4f71bc9c228ed847d7fab3180866971602cfc"
       ],
       "text": "Tempest, get back!",
       "source": "generated",

--- a/transcripts/butcher/rr_test_21_ping_tempest_back_01.mp3.json
+++ b/transcripts/butcher/rr_test_21_ping_tempest_back_01.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "c93968bd6ab4cec59269306d4135ede0d06b5ba0162c3a7e6f743f4ba95e3586"
       ],
-      "text": "Tappis, get back!",
+      "text": "Tempest, get back!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "b408a6643039e5b1b79612ba924ce440dc42bd0a6568ebe91097b6d1c33ae915"
       ],
-      "text": "Tapis, get back!",
+      "text": "Tempest, get back!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/dynamo/ping/prof_ping_hornet_on_top_of_garage.mp3.json
+++ b/transcripts/dynamo/ping/prof_ping_hornet_on_top_of_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "c66b73c98dd889102e1937e3ed264114a84c849450ef06bd64f329dc0622745b"
       ],
-      "text": "Vendict is on top of the garage!",
+      "text": "Vindicta is on top of the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "0374f5b8f554f3a9691051eefd8f23dd5cccf2871a7c1b0916d892c4deba2098"
       ],
-      "text": "Vendictus on top of the garage!",
+      "text": "Vindicta's on top of the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/dynamo/ping/prof_ping_orion_in_mid.mp3.json
+++ b/transcripts/dynamo/ping/prof_ping_orion_in_mid.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "f6a721f96af53718237fb09a21f522e451aec07fc2e7f0aa4020e9f72f8d61a1",
         "fea3d690ccafc3215bbbe594144ddcab6ff5429dee9bc2afd88e4ae9b6ebc77e"
-      ],
-      "text": "Grey Talon's in mid!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "f6a721f96af53718237fb09a21f522e451aec07fc2e7f0aa4020e9f72f8d61a1"
       ],
       "text": "Grey Talon's in mid!",
       "source": "generated",

--- a/transcripts/dynamo/ping/prof_ping_orion_in_mid.mp3.json
+++ b/transcripts/dynamo/ping/prof_ping_orion_in_mid.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "fea3d690ccafc3215bbbe594144ddcab6ff5429dee9bc2afd88e4ae9b6ebc77e"
       ],
-      "text": "Great talents in mid.",
+      "text": "Grey Talon's in mid!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "f6a721f96af53718237fb09a21f522e451aec07fc2e7f0aa4020e9f72f8d61a1"
       ],
-      "text": "Great talent in mid!",
+      "text": "Grey Talon's in mid!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/dynamo/ping/prof_ping_see_lash_on_roof.mp3.json
+++ b/transcripts/dynamo/ping/prof_ping_see_lash_on_roof.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "2b43b68f5affd4caadd8cdc94d49b90378956d1967e1552428775d54eb7309a5"
       ],
-      "text": "Clash on the roofs!",
+      "text": "Lash is on the roof!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "170fd067fafa2e1fcb15bfa862f9fada20801d944caf2cf19801781eda5e75cb"
       ],
-      "text": "Clash on the roof!",
+      "text": "Lash is on the roof!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/dynamo/ping/prof_ping_see_lash_on_roof.mp3.json
+++ b/transcripts/dynamo/ping/prof_ping_see_lash_on_roof.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "170fd067fafa2e1fcb15bfa862f9fada20801d944caf2cf19801781eda5e75cb",
         "2b43b68f5affd4caadd8cdc94d49b90378956d1967e1552428775d54eb7309a5"
-      ],
-      "text": "Lash is on the roof!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "170fd067fafa2e1fcb15bfa862f9fada20801d944caf2cf19801781eda5e75cb"
       ],
       "text": "Lash is on the roof!",
       "source": "generated",

--- a/transcripts/dynamo/ping/prof_ping_see_orion_on_roof.mp3.json
+++ b/transcripts/dynamo/ping/prof_ping_see_orion_on_roof.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "70d61ca0adfd857bb7ac17836b09e6e32ac4456660d379b30d77a65dd3b14f94"
       ],
-      "text": "Great talent on the roof!",
+      "text": "Grey Talon's on the roof!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "7321830e535719091dcc9e19869e94b3e8f91a79bec524eb51684603cd0b6ed7"
       ],
-      "text": "Great talents on the roof!",
+      "text": "Grey Talon's on the roof!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/dynamo/ping/prof_ping_see_orion_on_roof.mp3.json
+++ b/transcripts/dynamo/ping/prof_ping_see_orion_on_roof.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "70d61ca0adfd857bb7ac17836b09e6e32ac4456660d379b30d77a65dd3b14f94"
-      ],
-      "text": "Grey Talon's on the roof!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "70d61ca0adfd857bb7ac17836b09e6e32ac4456660d379b30d77a65dd3b14f94",
         "7321830e535719091dcc9e19869e94b3e8f91a79bec524eb51684603cd0b6ed7"
       ],
       "text": "Grey Talon's on the roof!",

--- a/transcripts/dynamo/ping/prof_ping_stim_pack_not_ready.mp3.json
+++ b/transcripts/dynamo/ping/prof_ping_stim_pack_not_ready.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "d569e7f860278f6bc3317020d18e8e399237af6207d3f5e6b880b0c542482596"
       ],
-      "text": "Healing rights on cooldown.",
+      "text": "Healing Rite's on cooldown.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "a5e38b4e1dcc6e96e6105a074a2de405513b01e0cec20540f912cac54499ea41"
       ],
-      "text": "Healing right on cooldown.",
+      "text": "Healing Rite's on cooldown.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/dynamo/ping/prof_ping_stim_pack_not_ready.mp3.json
+++ b/transcripts/dynamo/ping/prof_ping_stim_pack_not_ready.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "a5e38b4e1dcc6e96e6105a074a2de405513b01e0cec20540f912cac54499ea41",
         "d569e7f860278f6bc3317020d18e8e399237af6207d3f5e6b880b0c542482596"
-      ],
-      "text": "Healing Rite's on cooldown.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "a5e38b4e1dcc6e96e6105a074a2de405513b01e0cec20540f912cac54499ea41"
       ],
       "text": "Healing Rite's on cooldown.",
       "source": "generated",

--- a/transcripts/dynamo/prof_kill_warden_05.mp3.json
+++ b/transcripts/dynamo/prof_kill_warden_05.mp3.json
@@ -4,19 +4,11 @@
   "revisions": [
     {
       "sha256": [
-        "c871b65796da3e8c57e030148bf4f0e0088aa383251330d0a97e35239827f103"
-      ],
-      "text": "",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "c871b65796da3e8c57e030148bf4f0e0088aa383251330d0a97e35239827f103",
         "1cf3e5e3c72e1af7f9368f3dc6c384712ac7e0eebd3e22fc2bbe9c5a8a59ebf1"
       ],
-      "text": "",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
+      "text": "I don't trust zealots",
+      "source": "manual"
     }
   ]
 }

--- a/transcripts/dynamo/prof_kill_warden_05.mp3.json
+++ b/transcripts/dynamo/prof_kill_warden_05.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "c871b65796da3e8c57e030148bf4f0e0088aa383251330d0a97e35239827f103"
       ],
-      "text": "I don't trust Zealous.",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "1cf3e5e3c72e1af7f9368f3dc6c384712ac7e0eebd3e22fc2bbe9c5a8a59ebf1"
       ],
-      "text": "I don't trust Zealus.",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/forge/ping/mcginnis_ping_cadence_was_here.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_cadence_was_here.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "e96d6d7e3087a84f15cf7f4b49b56f95d975c88b62c82547bdc9c153b4e21352"
       ],
-      "text": "Cade's was here.",
+      "text": "Cadence was here.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "b57aac62b7ba5ae86b41d1878faad216a915b622d664d937927d814a52f7dd9f"
       ],
-      "text": "Cade is was here.",
+      "text": "Cadence was here.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/forge/ping/mcginnis_ping_cadence_was_here.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_cadence_was_here.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "b57aac62b7ba5ae86b41d1878faad216a915b622d664d937927d814a52f7dd9f",
         "e96d6d7e3087a84f15cf7f4b49b56f95d975c88b62c82547bdc9c153b4e21352"
-      ],
-      "text": "Cadence was here.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "b57aac62b7ba5ae86b41d1878faad216a915b622d664d937927d814a52f7dd9f"
       ],
       "text": "Cadence was here.",
       "source": "generated",

--- a/transcripts/forge/ping/mcginnis_ping_can_heal_pocket.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_can_heal_pocket.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "1597b07ce61b2e5c5c9b7537a613ff44d28cf2a1039bee24e2a65f08a4dd5e87",
         "eabb898b39bcace1206afeb47dc42a17e1f853869b4e123db93e97da0178a586"
-      ],
-      "text": "Pocket, I can heal you!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "1597b07ce61b2e5c5c9b7537a613ff44d28cf2a1039bee24e2a65f08a4dd5e87"
       ],
       "text": "Pocket, I can heal you!",
       "source": "generated",

--- a/transcripts/forge/ping/mcginnis_ping_can_heal_pocket.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_can_heal_pocket.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "eabb898b39bcace1206afeb47dc42a17e1f853869b4e123db93e97da0178a586"
       ],
-      "text": "Pockets, I can hear you!",
+      "text": "Pocket, I can heal you!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "1597b07ce61b2e5c5c9b7537a613ff44d28cf2a1039bee24e2a65f08a4dd5e87"
       ],
-      "text": "Pocket, I can hear you!",
+      "text": "Pocket, I can heal you!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/forge/ping/mcginnis_ping_can_heal_synth.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_can_heal_synth.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "1597b07ce61b2e5c5c9b7537a613ff44d28cf2a1039bee24e2a65f08a4dd5e87",
         "eabb898b39bcace1206afeb47dc42a17e1f853869b4e123db93e97da0178a586"
-      ],
-      "text": "Pocket, I can heal you!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "1597b07ce61b2e5c5c9b7537a613ff44d28cf2a1039bee24e2a65f08a4dd5e87"
       ],
       "text": "Pocket, I can heal you!",
       "source": "generated",

--- a/transcripts/forge/ping/mcginnis_ping_can_heal_synth.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_can_heal_synth.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "eabb898b39bcace1206afeb47dc42a17e1f853869b4e123db93e97da0178a586"
       ],
-      "text": "Pockets, I can hear you!",
+      "text": "Pocket, I can heal you!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "1597b07ce61b2e5c5c9b7537a613ff44d28cf2a1039bee24e2a65f08a4dd5e87"
       ],
-      "text": "Pocket, I can hear you!",
+      "text": "Pocket, I can heal you!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/forge/ping/mcginnis_ping_dynamo_under_garage.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_dynamo_under_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "ba0cbc119267d974e0862a6460597cfa94e9027a2d979ccd63fbf4e4f7890ffc"
       ],
-      "text": "Signpost under the garage!",
+      "text": "Dynamo's under the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "30d78a74e85b908557b30b54b9a26c9c5e189ebfb75c9fce6b91fb1d46b717c0"
       ],
-      "text": "Signposts under the garage!",
+      "text": "Dynamo's under the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/forge/ping/mcginnis_ping_dynamo_under_garage.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_dynamo_under_garage.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "30d78a74e85b908557b30b54b9a26c9c5e189ebfb75c9fce6b91fb1d46b717c0",
         "ba0cbc119267d974e0862a6460597cfa94e9027a2d979ccd63fbf4e4f7890ffc"
-      ],
-      "text": "Dynamo's under the garage!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "30d78a74e85b908557b30b54b9a26c9c5e189ebfb75c9fce6b91fb1d46b717c0"
       ],
       "text": "Dynamo's under the garage!",
       "source": "generated",

--- a/transcripts/forge/ping/mcginnis_ping_fairfax_on_top_of_garage.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_fairfax_on_top_of_garage.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "0649abdd5f8c10bb2c614e543a65f1c445e146525b92776e104228d1446c7e9b",
         "1549dd6da065358bbcac073cec023f4cd61be678136ff4a2678e584c23e86531"
-      ],
-      "text": "Fairfax is on top of the garage.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "0649abdd5f8c10bb2c614e543a65f1c445e146525b92776e104228d1446c7e9b"
       ],
       "text": "Fairfax is on top of the garage.",
       "source": "generated",

--- a/transcripts/forge/ping/mcginnis_ping_fairfax_on_top_of_garage.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_fairfax_on_top_of_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "1549dd6da065358bbcac073cec023f4cd61be678136ff4a2678e584c23e86531"
       ],
-      "text": "Grab that on top of the garage.",
+      "text": "Fairfax is on top of the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "0649abdd5f8c10bb2c614e543a65f1c445e146525b92776e104228d1446c7e9b"
       ],
-      "text": "Grab that's on top of the garage.",
+      "text": "Fairfax is on top of the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/forge/ping/mcginnis_ping_geist_on_top_of_mid.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_geist_on_top_of_mid.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "02d73af86d78ba1bf7be4ba1a6bc601eceedbd37e1227413f448069d8d718fc0"
-      ],
-      "text": "Geist is on top of mid!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "02d73af86d78ba1bf7be4ba1a6bc601eceedbd37e1227413f448069d8d718fc0",
         "dca893e2f7e17c8441d775d81e46b7a5710ef4788e256609705c0f4854e897e7"
       ],
       "text": "Geist is on top of mid!",

--- a/transcripts/forge/ping/mcginnis_ping_geist_on_top_of_mid.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_geist_on_top_of_mid.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "02d73af86d78ba1bf7be4ba1a6bc601eceedbd37e1227413f448069d8d718fc0"
       ],
-      "text": "Guys, it's on top of mid!",
+      "text": "Geist is on top of mid!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "dca893e2f7e17c8441d775d81e46b7a5710ef4788e256609705c0f4854e897e7"
       ],
-      "text": "Guys is on top of mid!",
+      "text": "Geist is on top of mid!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/forge/ping/mcginnis_ping_ghost_on_top_of_mid.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_ghost_on_top_of_mid.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "02d73af86d78ba1bf7be4ba1a6bc601eceedbd37e1227413f448069d8d718fc0"
-      ],
-      "text": "Geist is on top of mid!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "02d73af86d78ba1bf7be4ba1a6bc601eceedbd37e1227413f448069d8d718fc0",
         "dca893e2f7e17c8441d775d81e46b7a5710ef4788e256609705c0f4854e897e7"
       ],
       "text": "Geist is on top of mid!",

--- a/transcripts/forge/ping/mcginnis_ping_ghost_on_top_of_mid.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_ghost_on_top_of_mid.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "02d73af86d78ba1bf7be4ba1a6bc601eceedbd37e1227413f448069d8d718fc0"
       ],
-      "text": "Guys, it's on top of mid!",
+      "text": "Geist is on top of mid!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "dca893e2f7e17c8441d775d81e46b7a5710ef4788e256609705c0f4854e897e7"
       ],
-      "text": "Guys is on top of mid!",
+      "text": "Geist is on top of mid!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/forge/ping/mcginnis_ping_pocket_on_top_of_garage.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_pocket_on_top_of_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "1e3f1aa78b7cd114ebbf90ac7cf3bde46c35548f7b3e4c43594e5d345056e76a"
       ],
-      "text": "Park it on top of the garage!",
+      "text": "Pocket's on top of the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "e2e1c7f02c1cb18639238faf2f235b0592774a3e64fe058e784752e60c4e7ae5"
       ],
-      "text": "Park it's on top of the garage!",
+      "text": "Pocket's on top of the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/forge/ping/mcginnis_ping_pocket_on_top_of_garage.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_pocket_on_top_of_garage.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "1e3f1aa78b7cd114ebbf90ac7cf3bde46c35548f7b3e4c43594e5d345056e76a"
-      ],
-      "text": "Pocket's on top of the garage!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "1e3f1aa78b7cd114ebbf90ac7cf3bde46c35548f7b3e4c43594e5d345056e76a",
         "e2e1c7f02c1cb18639238faf2f235b0592774a3e64fe058e784752e60c4e7ae5"
       ],
       "text": "Pocket's on top of the garage!",

--- a/transcripts/forge/ping/mcginnis_ping_see_calico_on_bridge.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_see_calico_on_bridge.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "d346d26c0fdf048ed58680a055a70183526373bbdedeaf95e6ed4844bc99be21"
       ],
-      "text": "Calica's on the bridge!",
+      "text": "Calico's on the bridge!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "eac5fa4d8f6dc28f6230a7bb03fac3c70623b74d1377de3a154cad35d3769cf8"
       ],
-      "text": "Calca's on the bridge!",
+      "text": "Calico's on the bridge!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/forge/ping/mcginnis_ping_see_calico_on_bridge.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_see_calico_on_bridge.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "d346d26c0fdf048ed58680a055a70183526373bbdedeaf95e6ed4844bc99be21"
-      ],
-      "text": "Calico's on the bridge!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "d346d26c0fdf048ed58680a055a70183526373bbdedeaf95e6ed4844bc99be21",
         "eac5fa4d8f6dc28f6230a7bb03fac3c70623b74d1377de3a154cad35d3769cf8"
       ],
       "text": "Calico's on the bridge!",

--- a/transcripts/forge/ping/mcginnis_ping_synth_on_top_of_garage.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_synth_on_top_of_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "1e3f1aa78b7cd114ebbf90ac7cf3bde46c35548f7b3e4c43594e5d345056e76a"
       ],
-      "text": "Park it on top of the garage!",
+      "text": "Pocket's on top of the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "e2e1c7f02c1cb18639238faf2f235b0592774a3e64fe058e784752e60c4e7ae5"
       ],
-      "text": "Park it's on top of the garage!",
+      "text": "Pocket's on top of the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/forge/ping/mcginnis_ping_synth_on_top_of_garage.mp3.json
+++ b/transcripts/forge/ping/mcginnis_ping_synth_on_top_of_garage.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "1e3f1aa78b7cd114ebbf90ac7cf3bde46c35548f7b3e4c43594e5d345056e76a"
-      ],
-      "text": "Pocket's on top of the garage!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "1e3f1aa78b7cd114ebbf90ac7cf3bde46c35548f7b3e4c43594e5d345056e76a",
         "e2e1c7f02c1cb18639238faf2f235b0592774a3e64fe058e784752e60c4e7ae5"
       ],
       "text": "Pocket's on top of the garage!",

--- a/transcripts/ghost/geist_kill_anyhero_10.mp3.json
+++ b/transcripts/ghost/geist_kill_anyhero_10.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "39393e70cbf7a9a0652dddd0589314a1c5a6920be94d0af1291758c15e73939a"
-      ],
-      "text": "",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "39393e70cbf7a9a0652dddd0589314a1c5a6920be94d0af1291758c15e73939a",
         "f76b2ce92c8902485a3a44087db71ee89f3f965c9b22493ac9351d4518668e46"
       ],
       "text": "",

--- a/transcripts/ghost/geist_kill_anyhero_10.mp3.json
+++ b/transcripts/ghost/geist_kill_anyhero_10.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "39393e70cbf7a9a0652dddd0589314a1c5a6920be94d0af1291758c15e73939a"
       ],
-      "text": "To work on Kingus.",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "f76b2ce92c8902485a3a44087db71ee89f3f965c9b22493ac9351d4518668e46"
       ],
-      "text": "to work on King's.",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/ghost/geist_tower_got_denied_04.mp3.json
+++ b/transcripts/ghost/geist_tower_got_denied_04.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "cf797abb4f4cf9c8588cf3fc68ff3a4ca48d6468b333a70fb4180a6126c75be8"
       ],
-      "text": "The ritual is once set closer.",
+      "text": "The ritual is one step closer.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "a9f0e45c9c0338e9ef4945e2e4d017da179d0519e1f8f8bbd40a37c1fa3e0792"
       ],
-      "text": "The ritual is one set closer.",
+      "text": "The ritual is one step closer.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/ghost/geist_tower_got_denied_04.mp3.json
+++ b/transcripts/ghost/geist_tower_got_denied_04.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "a9f0e45c9c0338e9ef4945e2e4d017da179d0519e1f8f8bbd40a37c1fa3e0792",
         "cf797abb4f4cf9c8588cf3fc68ff3a4ca48d6468b333a70fb4180a6126c75be8"
-      ],
-      "text": "The ritual is one step closer.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "a9f0e45c9c0338e9ef4945e2e4d017da179d0519e1f8f8bbd40a37c1fa3e0792"
       ],
       "text": "The ritual is one step closer.",
       "source": "generated",

--- a/transcripts/ghost/geist_unselect_03.mp3.json
+++ b/transcripts/ghost/geist_unselect_03.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "e6261a14fd2161084c0799e9c4f358a0ac69aca1ed3db18e65d56f3e69f008c2"
-      ],
-      "text": "",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "e6261a14fd2161084c0799e9c4f358a0ac69aca1ed3db18e65d56f3e69f008c2",
         "e7e8e505bd9a298c8c4a9399cbaefbec6a0fdcd46373b40199ea1a56fc4914ad"
       ],
       "text": "",

--- a/transcripts/ghost/geist_unselect_03.mp3.json
+++ b/transcripts/ghost/geist_unselect_03.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "e6261a14fd2161084c0799e9c4f358a0ac69aca1ed3db18e65d56f3e69f008c2"
       ],
-      "text": "I was game for Skipper today.",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "e7e8e505bd9a298c8c4a9399cbaefbec6a0fdcd46373b40199ea1a56fc4914ad"
       ],
-      "text": "I was game for a skipper today.",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/ghost/ping/geist_ping_grey_talon_on_top_of_garage.mp3.json
+++ b/transcripts/ghost/ping/geist_ping_grey_talon_on_top_of_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "ad885bdebca90bad25d51aee27f2541f4a0cb1ad3716c9c9e08cb53159e0c2c4"
       ],
-      "text": "Great ammo on top of the garage!",
+      "text": "Grey Talon is on top of the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "d664cc02ecab50771c878bf9a68f337ce81adc361303027bb1945b9022a8bc73"
       ],
-      "text": "Great ammo's on top of the garage.",
+      "text": "Grey Talon's on top of the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/ghost/ping/geist_ping_grey_talon_under_garage.mp3.json
+++ b/transcripts/ghost/ping/geist_ping_grey_talon_under_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "826fa0a78a79889a09b22b8416507bf044b87a5e3883a1d7322c090a4dd4313d"
       ],
-      "text": "Great talent under the garage.",
+      "text": "Grey Talon is under the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "2c6416fe7ee4979591ccd7648b6cd9684101e3453c870e825ece32d942b69f48"
       ],
-      "text": "Great talent's under the garage.",
+      "text": "Grey Talon's under the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/ghost/ping/geist_ping_krill_check_items.mp3.json
+++ b/transcripts/ghost/ping/geist_ping_krill_check_items.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "91adbbc5498fd2fa78432f32f1b5b5e3971ce32bb9be720616a3a252a04368fe",
         "d5da6d04618b13ddcca3ee5b5f37b48b7bfaf3a4b5769b439492d661905704c0"
-      ],
-      "text": "Check out what Krill bought.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "91adbbc5498fd2fa78432f32f1b5b5e3971ce32bb9be720616a3a252a04368fe"
       ],
       "text": "Check out what Krill bought.",
       "source": "generated",

--- a/transcripts/ghost/ping/geist_ping_krill_check_items.mp3.json
+++ b/transcripts/ghost/ping/geist_ping_krill_check_items.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "d5da6d04618b13ddcca3ee5b5f37b48b7bfaf3a4b5769b439492d661905704c0"
       ],
-      "text": "Check out what Krillwort.",
+      "text": "Check out what Krill bought.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "91adbbc5498fd2fa78432f32f1b5b5e3971ce32bb9be720616a3a252a04368fe"
       ],
-      "text": "Check out what Krillworth.",
+      "text": "Check out what Krill bought.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/ghost/ping/geist_ping_orion_on_top_of_garage.mp3.json
+++ b/transcripts/ghost/ping/geist_ping_orion_on_top_of_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "ad885bdebca90bad25d51aee27f2541f4a0cb1ad3716c9c9e08cb53159e0c2c4"
       ],
-      "text": "Great ammo on top of the garage!",
+      "text": "Grey Talon is on top of the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "d664cc02ecab50771c878bf9a68f337ce81adc361303027bb1945b9022a8bc73"
       ],
-      "text": "Great ammo's on top of the garage.",
+      "text": "Grey Talon's on top of the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/ghost/ping/geist_ping_orion_under_garage.mp3.json
+++ b/transcripts/ghost/ping/geist_ping_orion_under_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "826fa0a78a79889a09b22b8416507bf044b87a5e3883a1d7322c090a4dd4313d"
       ],
-      "text": "Great talent under the garage.",
+      "text": "Grey Talon is under the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "2c6416fe7ee4979591ccd7648b6cd9684101e3453c870e825ece32d942b69f48"
       ],
-      "text": "Great talent's under the garage.",
+      "text": "Grey Talon's under the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/ghost/ping/geist_ping_pocket_check_items.mp3.json
+++ b/transcripts/ghost/ping/geist_ping_pocket_check_items.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "349a7898550487975d07d1299d1eb69e134d9f3a7a7bbca3040da5ea390c6a03"
-      ],
-      "text": "Check out what Pocket bought.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "349a7898550487975d07d1299d1eb69e134d9f3a7a7bbca3040da5ea390c6a03",
         "5ee8f24048c1f454c83079e9c1346ad34d542e90c50df98ae62809532fa8f0a7"
       ],
       "text": "Check out what Pocket bought.",

--- a/transcripts/ghost/ping/geist_ping_pocket_check_items.mp3.json
+++ b/transcripts/ghost/ping/geist_ping_pocket_check_items.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "349a7898550487975d07d1299d1eb69e134d9f3a7a7bbca3040da5ea390c6a03"
       ],
-      "text": "Check out what PocketBot...",
+      "text": "Check out what Pocket bought.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "5ee8f24048c1f454c83079e9c1346ad34d542e90c50df98ae62809532fa8f0a7"
       ],
-      "text": "Check out what PocketBolt.",
+      "text": "Check out what Pocket bought.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/ghost/ping/geist_ping_shiv_on_top_of_mid.mp3.json
+++ b/transcripts/ghost/ping/geist_ping_shiv_on_top_of_mid.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "3430495c0ce67ed568916cc4e3b86cc1954a4af32d333503217c7ea99db8ab85"
       ],
-      "text": "She is on top of me!",
+      "text": "Shiv is on top of mid!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "097b1047eaf840f2c256c10b570aa0af808afea4fab572518d9abe432e0f9a17"
       ],
-      "text": "She's on top of me!",
+      "text": "Shiv is on top of mid!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/ghost/ping/geist_ping_shiv_on_top_of_mid.mp3.json
+++ b/transcripts/ghost/ping/geist_ping_shiv_on_top_of_mid.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "097b1047eaf840f2c256c10b570aa0af808afea4fab572518d9abe432e0f9a17",
         "3430495c0ce67ed568916cc4e3b86cc1954a4af32d333503217c7ea99db8ab85"
-      ],
-      "text": "Shiv is on top of mid!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "097b1047eaf840f2c256c10b570aa0af808afea4fab572518d9abe432e0f9a17"
       ],
       "text": "Shiv is on top of mid!",
       "source": "generated",

--- a/transcripts/ghost/ping/geist_ping_stun_astro_01.mp3.json
+++ b/transcripts/ghost/ping/geist_ping_stun_astro_01.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "27c878dc77530b6ba56c2208e86f60e9a8503b4223df400f5d145f63b842ee8c"
-      ],
-      "text": "Stun Holliday.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "27c878dc77530b6ba56c2208e86f60e9a8503b4223df400f5d145f63b842ee8c",
         "7a7aa1bd4fe94c464875a2bb16686df8d0faeeee542f55d5e7dc9649d1dae85d"
       ],
       "text": "Stun Holliday.",

--- a/transcripts/ghost/ping/geist_ping_stun_astro_01.mp3.json
+++ b/transcripts/ghost/ping/geist_ping_stun_astro_01.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "27c878dc77530b6ba56c2208e86f60e9a8503b4223df400f5d145f63b842ee8c"
       ],
-      "text": "Stan Holliday.",
+      "text": "Stun Holliday.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "7a7aa1bd4fe94c464875a2bb16686df8d0faeeee542f55d5e7dc9649d1dae85d"
       ],
-      "text": "Stand, Holliday.",
+      "text": "Stun Holliday.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/ghost/ping/geist_ping_stun_holliday_01.mp3.json
+++ b/transcripts/ghost/ping/geist_ping_stun_holliday_01.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "27c878dc77530b6ba56c2208e86f60e9a8503b4223df400f5d145f63b842ee8c"
-      ],
-      "text": "Stun Holliday.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "27c878dc77530b6ba56c2208e86f60e9a8503b4223df400f5d145f63b842ee8c",
         "7a7aa1bd4fe94c464875a2bb16686df8d0faeeee542f55d5e7dc9649d1dae85d"
       ],
       "text": "Stun Holliday.",

--- a/transcripts/ghost/ping/geist_ping_stun_holliday_01.mp3.json
+++ b/transcripts/ghost/ping/geist_ping_stun_holliday_01.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "27c878dc77530b6ba56c2208e86f60e9a8503b4223df400f5d145f63b842ee8c"
       ],
-      "text": "Stan Holliday.",
+      "text": "Stun Holliday.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "7a7aa1bd4fe94c464875a2bb16686df8d0faeeee542f55d5e7dc9649d1dae85d"
       ],
-      "text": "Stand, Holliday.",
+      "text": "Stun Holliday.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/ghost/ping/geist_ping_synth_check_items.mp3.json
+++ b/transcripts/ghost/ping/geist_ping_synth_check_items.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "349a7898550487975d07d1299d1eb69e134d9f3a7a7bbca3040da5ea390c6a03"
-      ],
-      "text": "Check out what Pocket bought.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "349a7898550487975d07d1299d1eb69e134d9f3a7a7bbca3040da5ea390c6a03",
         "5ee8f24048c1f454c83079e9c1346ad34d542e90c50df98ae62809532fa8f0a7"
       ],
       "text": "Check out what Pocket bought.",

--- a/transcripts/ghost/ping/geist_ping_synth_check_items.mp3.json
+++ b/transcripts/ghost/ping/geist_ping_synth_check_items.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "349a7898550487975d07d1299d1eb69e134d9f3a7a7bbca3040da5ea390c6a03"
       ],
-      "text": "Check out what PocketBot...",
+      "text": "Check out what Pocket bought.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "5ee8f24048c1f454c83079e9c1346ad34d542e90c50df98ae62809532fa8f0a7"
       ],
-      "text": "Check out what PocketBolt.",
+      "text": "Check out what Pocket bought.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/gigawatt/gigawatt_ally_wraith_kill_in_lift_03.mp3.json
+++ b/transcripts/gigawatt/gigawatt_ally_wraith_kill_in_lift_03.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "370f51dec979f4c6c892cb0452b8dd4368ee23b0b53d386b81edf588c13859cc"
       ],
-      "text": "You played your part well, brave.",
+      "text": "You played your part well, Wraith.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "3ce4837407ab21d86cd539e6331cb2dfb3141a413db51a6bcd29da35d904c058"
       ],
-      "text": "You played your part well, Raze.",
+      "text": "You played your part well, Wraith.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/gigawatt/gigawatt_ally_wraith_kill_in_lift_03.mp3.json
+++ b/transcripts/gigawatt/gigawatt_ally_wraith_kill_in_lift_03.mp3.json
@@ -4,30 +4,9 @@
   "revisions": [
     {
       "sha256": [
-        "370f51dec979f4c6c892cb0452b8dd4368ee23b0b53d386b81edf588c13859cc"
-      ],
-      "text": "You played your part well, Wraith.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "cb3c10696018285e90128da6bd24524e88182b96f7e993cdb7662f94174c3ab3"
-      ],
-      "text": "You played your part well, Wraith.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "3ce4837407ab21d86cd539e6331cb2dfb3141a413db51a6bcd29da35d904c058"
-      ],
-      "text": "You played your part well, Wraith.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "370f51dec979f4c6c892cb0452b8dd4368ee23b0b53d386b81edf588c13859cc",
+        "3ce4837407ab21d86cd539e6331cb2dfb3141a413db51a6bcd29da35d904c058",
+        "cb3c10696018285e90128da6bd24524e88182b96f7e993cdb7662f94174c3ab3",
         "ee6eb065e7914628a49a5a837161f1fd68da866182c49b9f7bc0a2328a7342df"
       ],
       "text": "You played your part well, Wraith.",

--- a/transcripts/gigawatt/ping/gigawatt_ping_bebop_almost_respawn.mp3.json
+++ b/transcripts/gigawatt/ping/gigawatt_ping_bebop_almost_respawn.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "36e663ed335a202319e72b5a7076802464e540ecd10410eaf46447e91ecd02f2"
       ],
-      "text": "The bob is almost back.",
+      "text": "Bebop is almost back.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "a6be0a86d056f74ce1650d001d7fcda687a8d6cc7c13210ad60caf7887ad5bd1"
       ],
-      "text": "The bomb is almost back.",
+      "text": "Bebop is almost back.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/gigawatt/ping/gigawatt_ping_bebop_almost_respawn.mp3.json
+++ b/transcripts/gigawatt/ping/gigawatt_ping_bebop_almost_respawn.mp3.json
@@ -4,23 +4,9 @@
   "revisions": [
     {
       "sha256": [
-        "36e663ed335a202319e72b5a7076802464e540ecd10410eaf46447e91ecd02f2"
-      ],
-      "text": "Bebop is almost back.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "1f587dc2630905f72ee1fc5ecf316413a6817ce39c757c9900a73ab29907f6e1",
+        "36e663ed335a202319e72b5a7076802464e540ecd10410eaf46447e91ecd02f2",
         "a6be0a86d056f74ce1650d001d7fcda687a8d6cc7c13210ad60caf7887ad5bd1"
-      ],
-      "text": "Bebop is almost back.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "1f587dc2630905f72ee1fc5ecf316413a6817ce39c757c9900a73ab29907f6e1"
       ],
       "text": "Bebop is almost back.",
       "source": "generated",

--- a/transcripts/gigawatt/ping/gigawatt_ping_ignore_synth.mp3.json
+++ b/transcripts/gigawatt/ping/gigawatt_ping_ignore_synth.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "2996b1155a229a622472cb539f461a614a13c76244d606ab05c5c594b166d66e"
       ],
-      "text": "Ignore Pocket!",
+      "text": "Ignore Pocket.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "53d4d928b190260312db94ec8c966116d04f44c21e2de2d73715f02a689b15a9"
       ],
-      "text": "Ignore Pockets.",
+      "text": "Ignore Pocket.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/gigawatt/ping/gigawatt_ping_ignore_synth.mp3.json
+++ b/transcripts/gigawatt/ping/gigawatt_ping_ignore_synth.mp3.json
@@ -4,22 +4,8 @@
   "revisions": [
     {
       "sha256": [
-        "1ce15259b08d5a384e00bedd15ae72bc6137336cf786b1db3ea3fb20bbc71df4"
-      ],
-      "text": "Ignore pocket.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "2996b1155a229a622472cb539f461a614a13c76244d606ab05c5c594b166d66e"
-      ],
-      "text": "Ignore Pocket.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "1ce15259b08d5a384e00bedd15ae72bc6137336cf786b1db3ea3fb20bbc71df4",
+        "2996b1155a229a622472cb539f461a614a13c76244d606ab05c5c594b166d66e",
         "53d4d928b190260312db94ec8c966116d04f44c21e2de2d73715f02a689b15a9"
       ],
       "text": "Ignore Pocket.",

--- a/transcripts/gigawatt/ping/gigawatt_ping_missing_orange_01.mp3.json
+++ b/transcripts/gigawatt/ping/gigawatt_ping_missing_orange_01.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "83301fee8b598cb968ab59d950e5a9d0903f30014071c9b5f3ae4c76f1f1916e"
       ],
-      "text": "mission archives.",
+      "text": "Orange is missing.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "c083bb3a7cacfce36a98db33d27b788027e1e2d21497997e8004e443e1849ab9"
       ],
-      "text": "Mission archive.",
+      "text": "Orange is missing.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/gigawatt/ping/gigawatt_ping_missing_orange_01.mp3.json
+++ b/transcripts/gigawatt/ping/gigawatt_ping_missing_orange_01.mp3.json
@@ -12,14 +12,7 @@
     },
     {
       "sha256": [
-        "83301fee8b598cb968ab59d950e5a9d0903f30014071c9b5f3ae4c76f1f1916e"
-      ],
-      "text": "Orange is missing.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "83301fee8b598cb968ab59d950e5a9d0903f30014071c9b5f3ae4c76f1f1916e",
         "c083bb3a7cacfce36a98db33d27b788027e1e2d21497997e8004e443e1849ab9"
       ],
       "text": "Orange is missing.",

--- a/transcripts/gigawatt/ping/gigawatt_ping_synth_missing_01.mp3.json
+++ b/transcripts/gigawatt/ping/gigawatt_ping_synth_missing_01.mp3.json
@@ -12,22 +12,8 @@
     },
     {
       "sha256": [
-        "524f64b7113ed518e65ccc88aec317090685d8140bf7d068ee0489c068e04ecd"
-      ],
-      "text": "Pocket's missing.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "4d633a177251df7ce70f78a7f1b734cc27ddd0696996e6b8c0bb76c5e1ee215b"
-      ],
-      "text": "Pocket's missing.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "4d633a177251df7ce70f78a7f1b734cc27ddd0696996e6b8c0bb76c5e1ee215b",
+        "524f64b7113ed518e65ccc88aec317090685d8140bf7d068ee0489c068e04ecd",
         "a9ea644b00c5042fe8fb88605ba445333d1d82684e92b7db8cacfe5fb25760e0"
       ],
       "text": "Pocket's missing",

--- a/transcripts/gigawatt/ping/gigawatt_ping_synth_missing_01.mp3.json
+++ b/transcripts/gigawatt/ping/gigawatt_ping_synth_missing_01.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "524f64b7113ed518e65ccc88aec317090685d8140bf7d068ee0489c068e04ecd"
       ],
-      "text": "Target missing.",
+      "text": "Pocket's missing.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "4d633a177251df7ce70f78a7f1b734cc27ddd0696996e6b8c0bb76c5e1ee215b"
       ],
-      "text": "Targets missing.",
+      "text": "Pocket's missing.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/gigawatt/ping/gigawatt_ping_warden_on_top_of_mid.mp3.json
+++ b/transcripts/gigawatt/ping/gigawatt_ping_warden_on_top_of_mid.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "81929a4741858bd3adc0334591a3f79f794d2deb7786916fbe165b943313729c",
         "824efb7b9bf89e629fe86dfb3eb6997099f695999c947cd34b43502c0d3e18a8"
-      ],
-      "text": "Warden is on top of mid!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "81929a4741858bd3adc0334591a3f79f794d2deb7786916fbe165b943313729c"
       ],
       "text": "Warden is on top of mid!",
       "source": "generated",

--- a/transcripts/gigawatt/ping/gigawatt_ping_warden_on_top_of_mid.mp3.json
+++ b/transcripts/gigawatt/ping/gigawatt_ping_warden_on_top_of_mid.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "824efb7b9bf89e629fe86dfb3eb6997099f695999c947cd34b43502c0d3e18a8"
       ],
-      "text": "Warning on top of me!",
+      "text": "Warden is on top of mid!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "81929a4741858bd3adc0334591a3f79f794d2deb7786916fbe165b943313729c"
       ],
-      "text": "Warning's on top of me!",
+      "text": "Warden is on top of mid!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/gigawatt/ping/gigawatt_ping_yamato_on_top_of_mid.mp3.json
+++ b/transcripts/gigawatt/ping/gigawatt_ping_yamato_on_top_of_mid.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "b3fa08c31420b8b3512867326a062400569ef881709662b69f592e1581afcbe8"
       ],
-      "text": "I'm a chose on top of mig.",
+      "text": "Yamato's on top of mid!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "54dcdbf8b82fc961c0348f62c02a05ed3c579aff367b0b87d9182e0c8572a045"
       ],
-      "text": "I'm a chosen on top of MIG!",
+      "text": "Yamato's on top of mid!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/gigawatt/ping/gigawatt_ping_yamato_on_top_of_mid.mp3.json
+++ b/transcripts/gigawatt/ping/gigawatt_ping_yamato_on_top_of_mid.mp3.json
@@ -12,23 +12,9 @@
     },
     {
       "sha256": [
+        "54dcdbf8b82fc961c0348f62c02a05ed3c579aff367b0b87d9182e0c8572a045",
+        "57355acfda93104b855cf7bc634d45869155e2932cee713705354c1dd12196d1",
         "b3fa08c31420b8b3512867326a062400569ef881709662b69f592e1581afcbe8"
-      ],
-      "text": "Yamato's on top of mid!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "54dcdbf8b82fc961c0348f62c02a05ed3c579aff367b0b87d9182e0c8572a045"
-      ],
-      "text": "Yamato's on top of mid!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "57355acfda93104b855cf7bc634d45869155e2932cee713705354c1dd12196d1"
       ],
       "text": "Yamato's on top of mid!",
       "source": "official"

--- a/transcripts/haze/haze_ally_ghost_see_big_swap_02.mp3.json
+++ b/transcripts/haze/haze_ally_ghost_see_big_swap_02.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "673ae38dad45ef8a3e38bb3cd36ebb83883d84163ba25f2dc964f11144e7da54"
       ],
-      "text": "Gate made an opening!",
+      "text": "Geist made an opening!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "4d5107cf401c70fbf7631d89f7a69cf5dc8b5bc0c3ad1ec60e048029baaf21d0"
       ],
-      "text": "Gate's made an opening!",
+      "text": "Geist made an opening!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -38,7 +38,7 @@
       "sha256": [
         "db37511f58b7587f5d2c53d20c60d3357095b4c2327d11c5fde38165a3352f47"
       ],
-      "text": "Gaze made an opening!",
+      "text": "Geist made an opening!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/haze/haze_ally_ghost_see_big_swap_02.mp3.json
+++ b/transcripts/haze/haze_ally_ghost_see_big_swap_02.mp3.json
@@ -12,30 +12,9 @@
     },
     {
       "sha256": [
-        "673ae38dad45ef8a3e38bb3cd36ebb83883d84163ba25f2dc964f11144e7da54"
-      ],
-      "text": "Geist made an opening!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "4d5107cf401c70fbf7631d89f7a69cf5dc8b5bc0c3ad1ec60e048029baaf21d0"
-      ],
-      "text": "Geist made an opening!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "78ffd1f0620116e5c4f959f2273511fe754a5a8efc1cb36fe166be85d5cb4e78"
-      ],
-      "text": "Geist made an opening!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "4d5107cf401c70fbf7631d89f7a69cf5dc8b5bc0c3ad1ec60e048029baaf21d0",
+        "673ae38dad45ef8a3e38bb3cd36ebb83883d84163ba25f2dc964f11144e7da54",
+        "78ffd1f0620116e5c4f959f2273511fe754a5a8efc1cb36fe166be85d5cb4e78",
         "db37511f58b7587f5d2c53d20c60d3357095b4c2327d11c5fde38165a3352f47"
       ],
       "text": "Geist made an opening!",

--- a/transcripts/haze/ping/haze_ping_careful_sandeep_02.mp3.json
+++ b/transcripts/haze/ping/haze_ping_careful_sandeep_02.mp3.json
@@ -4,23 +4,9 @@
   "revisions": [
     {
       "sha256": [
-        "d120143816312e764a880f679d751f88084f55aae7e4052a892aa534b05213d1"
-      ],
-      "text": "Careful, Sandeep.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "c7bb226fda40a47d41b32a45c66d759aabb10ee67c5597425b2a0ec3897243d3"
-      ],
-      "text": "Careful, Sandeep.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
         "7fde422f7b7e8c2dcfc6f5b3fccb6940b65bc9cdd0c057b8b2b4aadf56086bd2",
+        "c7bb226fda40a47d41b32a45c66d759aabb10ee67c5597425b2a0ec3897243d3",
+        "d120143816312e764a880f679d751f88084f55aae7e4052a892aa534b05213d1",
         "e712c9af14100392156e0e14d829ddb8a3c8c002beea93e26cb4cd1b36f91edc"
       ],
       "text": "Careful, Sandeep.",

--- a/transcripts/haze/ping/haze_ping_careful_sandeep_02.mp3.json
+++ b/transcripts/haze/ping/haze_ping_careful_sandeep_02.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "d120143816312e764a880f679d751f88084f55aae7e4052a892aa534b05213d1"
       ],
-      "text": "Careful, Santin.",
+      "text": "Careful, Sandeep.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "c7bb226fda40a47d41b32a45c66d759aabb10ee67c5597425b2a0ec3897243d3"
       ],
-      "text": "Careful, Santy.",
+      "text": "Careful, Sandeep.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -23,7 +23,7 @@
         "7fde422f7b7e8c2dcfc6f5b3fccb6940b65bc9cdd0c057b8b2b4aadf56086bd2",
         "e712c9af14100392156e0e14d829ddb8a3c8c002beea93e26cb4cd1b36f91edc"
       ],
-      "text": "Careful, Santi.",
+      "text": "Careful, Sandeep.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/haze/ping/haze_ping_murphy_missing_01.mp3.json
+++ b/transcripts/haze/ping/haze_ping_murphy_missing_01.mp3.json
@@ -7,7 +7,7 @@
         "0fb89b464149994d7e7a99dfccb11e497006f644177b9199b724e4161f17a4ec",
         "f1d8106e4064e4a2ffa31d9424e0fffdb1de25f60e1b262abf4c7a8bf9412845"
       ],
-      "text": "Mercy is missing.",
+      "text": "Murphy is missing.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -23,7 +23,7 @@
       "sha256": [
         "6ff54e775a0b074907bacc012caf374b54b5e7d804dd2a5493756c6f95a41ae2"
       ],
-      "text": "Mercy's missing.",
+      "text": "Murphy's missing.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/haze/ping/haze_ping_with_astro.mp3.json
+++ b/transcripts/haze/ping/haze_ping_with_astro.mp3.json
@@ -4,25 +4,11 @@
   "revisions": [
     {
       "sha256": [
-        "30b29fcc79c454d86d6c84fe25e7607f2865cb7ad334d7260a8329085f0f0177"
-      ],
-      "text": "I'm with you, Holliday.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "30b29fcc79c454d86d6c84fe25e7607f2865cb7ad334d7260a8329085f0f0177",
         "3e130a4ad3e919b746353ccaed0fe2ad474ee713d9e30440c8928b024900fd99",
+        "6f03dbd123dad2ce8bbe757a45f802bb39a0be242b5b93bc2d7f364b9ba373d4",
         "9633773af54d23108e2dd7b8041d1b2ca2814da9dd84a0d2c83d30c7ead6b482",
         "b34efbff80ddf7e48f361acf30d7967029503dbf3a2b525b666010710a117a9e"
-      ],
-      "text": "I'm with you, Holliday.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "6f03dbd123dad2ce8bbe757a45f802bb39a0be242b5b93bc2d7f364b9ba373d4"
       ],
       "text": "I'm with you, Holliday.",
       "source": "generated",

--- a/transcripts/haze/ping/haze_ping_with_astro.mp3.json
+++ b/transcripts/haze/ping/haze_ping_with_astro.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "30b29fcc79c454d86d6c84fe25e7607f2865cb7ad334d7260a8329085f0f0177"
       ],
-      "text": "I'm you, Holliday.",
+      "text": "I'm with you, Holliday.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -24,7 +24,7 @@
       "sha256": [
         "6f03dbd123dad2ce8bbe757a45f802bb39a0be242b5b93bc2d7f364b9ba373d4"
       ],
-      "text": "I'm a you, Holliday.",
+      "text": "I'm with you, Holliday.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/haze/ping/haze_ping_with_holliday.mp3.json
+++ b/transcripts/haze/ping/haze_ping_with_holliday.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "30b29fcc79c454d86d6c84fe25e7607f2865cb7ad334d7260a8329085f0f0177"
       ],
-      "text": "I'm you, Holliday.",
+      "text": "I'm with you, Holliday.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/haze/ping/haze_ping_with_holliday.mp3.json
+++ b/transcripts/haze/ping/haze_ping_with_holliday.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "30b29fcc79c454d86d6c84fe25e7607f2865cb7ad334d7260a8329085f0f0177"
-      ],
-      "text": "I'm with you, Holliday.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "30b29fcc79c454d86d6c84fe25e7607f2865cb7ad334d7260a8329085f0f0177",
         "3e130a4ad3e919b746353ccaed0fe2ad474ee713d9e30440c8928b024900fd99",
         "9633773af54d23108e2dd7b8041d1b2ca2814da9dd84a0d2c83d30c7ead6b482",
         "b34efbff80ddf7e48f361acf30d7967029503dbf3a2b525b666010710a117a9e"

--- a/transcripts/haze/ping/haze_ping_with_shiv.mp3.json
+++ b/transcripts/haze/ping/haze_ping_with_shiv.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "8d0f55e7212d3c496baac6df04547686ec4c58c271cc4dfbd422a98fd3d1e9b2"
       ],
-      "text": "I'm with you, Schez.",
+      "text": "I'm with you, Shiv.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -30,7 +30,7 @@
       "sha256": [
         "a303531eb98c50dac0cde8eb54e01401c4a1841cb20de7e55a52a5dc03d161e9"
       ],
-      "text": "I'm with you, Shez.",
+      "text": "I'm with you, Shiv.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/haze/ping/haze_ping_with_shiv.mp3.json
+++ b/transcripts/haze/ping/haze_ping_with_shiv.mp3.json
@@ -4,15 +4,10 @@
   "revisions": [
     {
       "sha256": [
-        "560d96da58a238f6c53532e8b0968007257549e12812dfe781d2996b4b329234"
-      ],
-      "text": "I'm with you, Shiv.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "8d0f55e7212d3c496baac6df04547686ec4c58c271cc4dfbd422a98fd3d1e9b2"
+        "560d96da58a238f6c53532e8b0968007257549e12812dfe781d2996b4b329234",
+        "8d0f55e7212d3c496baac6df04547686ec4c58c271cc4dfbd422a98fd3d1e9b2",
+        "a303531eb98c50dac0cde8eb54e01401c4a1841cb20de7e55a52a5dc03d161e9",
+        "f37a65a77ae6e7a60d20d5f7aae88ea1e8ad353099af972ec4bcf8c7e8c1c0b7"
       ],
       "text": "I'm with you, Shiv.",
       "source": "generated",
@@ -23,22 +18,6 @@
         "2acf2cbd8087fdb8842f94e2b4ad0b1e9e2697d72f0621d33b8b4799c8e2873b"
       ],
       "text": "I'm with you, Chess.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "a303531eb98c50dac0cde8eb54e01401c4a1841cb20de7e55a52a5dc03d161e9"
-      ],
-      "text": "I'm with you, Shiv.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "f37a65a77ae6e7a60d20d5f7aae88ea1e8ad353099af972ec4bcf8c7e8c1c0b7"
-      ],
-      "text": "I'm with you, Shiv.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/haze/ping/haze_ping_wrecker_check_items.mp3.json
+++ b/transcripts/haze/ping/haze_ping_wrecker_check_items.mp3.json
@@ -4,32 +4,11 @@
   "revisions": [
     {
       "sha256": [
-        "83113cba4c5b672a6b621a4782a8fcdf75b995dcd518c81f738bf1f1006b27f6"
-      ],
-      "text": "Check out what Wrecker bought.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
         "4d3f10aed4153a34355ca164cc0f5ce7b706e4cec34be4c97a166748efe9b1b2",
+        "7cd1128187385a91447ae1a1385ef9e7d7fe73dfd65b281ffc55307bd0f75ac4",
+        "83113cba4c5b672a6b621a4782a8fcdf75b995dcd518c81f738bf1f1006b27f6",
+        "d63f43685bc899354c7857c39e33894161674d74441698180fe35d03eb5a04cf",
         "f8eb6847276669ffe2cd38ba763040c6f2faa9af5ab5971a74b3ac18dd8cf180"
-      ],
-      "text": "Check out what Wrecker bought.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "d63f43685bc899354c7857c39e33894161674d74441698180fe35d03eb5a04cf"
-      ],
-      "text": "Check out what Wrecker bought.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "7cd1128187385a91447ae1a1385ef9e7d7fe73dfd65b281ffc55307bd0f75ac4"
       ],
       "text": "Check out what Wrecker bought.",
       "source": "generated",

--- a/transcripts/haze/ping/haze_ping_wrecker_check_items.mp3.json
+++ b/transcripts/haze/ping/haze_ping_wrecker_check_items.mp3.json
@@ -15,7 +15,7 @@
         "4d3f10aed4153a34355ca164cc0f5ce7b706e4cec34be4c97a166748efe9b1b2",
         "f8eb6847276669ffe2cd38ba763040c6f2faa9af5ab5971a74b3ac18dd8cf180"
       ],
-      "text": "Check out what Record bought.",
+      "text": "Check out what Wrecker bought.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -23,7 +23,7 @@
       "sha256": [
         "d63f43685bc899354c7857c39e33894161674d74441698180fe35d03eb5a04cf"
       ],
-      "text": "Check out what RecordBot.",
+      "text": "Check out what Wrecker bought.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -31,7 +31,7 @@
       "sha256": [
         "7cd1128187385a91447ae1a1385ef9e7d7fe73dfd65b281ffc55307bd0f75ac4"
       ],
-      "text": "Check out what Wrecker bought!",
+      "text": "Check out what Wrecker bought.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/haze/ping/haze_ping_wrecker_dead.mp3.json
+++ b/transcripts/haze/ping/haze_ping_wrecker_dead.mp3.json
@@ -15,7 +15,7 @@
       "sha256": [
         "698eb885db10e8d42a0a9b27221b05c3f471d4bb3df3cf455fba94580b2c466c"
       ],
-      "text": "Rekker is dead.",
+      "text": "Wrecker is dead.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -23,7 +23,7 @@
       "sha256": [
         "7eb95fbca1f0e0ef853057b8e3c07c68e81aba57ec92196d1246939581dafe8f"
       ],
-      "text": "Brekker is dead.",
+      "text": "Wrecker is dead.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/haze/ping/haze_ping_wrecker_dead.mp3.json
+++ b/transcripts/haze/ping/haze_ping_wrecker_dead.mp3.json
@@ -5,30 +5,9 @@
     {
       "sha256": [
         "48c0c035eca62981088ab31c66601281927abb937bff6962d7bbac37b28063c2",
-        "60d5be5515cd5610bf525f45e6ab2edcb0e03032ca813b5bf1a79ede3ca2fae2"
-      ],
-      "text": "Wrecker is dead.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "698eb885db10e8d42a0a9b27221b05c3f471d4bb3df3cf455fba94580b2c466c"
-      ],
-      "text": "Wrecker is dead.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "7eb95fbca1f0e0ef853057b8e3c07c68e81aba57ec92196d1246939581dafe8f"
-      ],
-      "text": "Wrecker is dead.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "60d5be5515cd5610bf525f45e6ab2edcb0e03032ca813b5bf1a79ede3ca2fae2",
+        "698eb885db10e8d42a0a9b27221b05c3f471d4bb3df3cf455fba94580b2c466c",
+        "7eb95fbca1f0e0ef853057b8e3c07c68e81aba57ec92196d1246939581dafe8f",
         "ae661f5e0125960804257b39db56cb12d312e1a033d84815e59fddf95b21f3a2"
       ],
       "text": "Wrecker is dead.",

--- a/transcripts/hornet/ping/vindicta_ping_can_heal_astro.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_can_heal_astro.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "9775d38cf418141ece999c3e974e531dbb287585d4902aaaaeda58491475e3b8"
-      ],
-      "text": "Holliday, I can heal you.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "9775d38cf418141ece999c3e974e531dbb287585d4902aaaaeda58491475e3b8",
         "99ab2f0a37867649fd00914d82600bdbfd8285f8847b00e0f3b2be4ae1163680"
       ],
       "text": "Holliday, I can heal you.",

--- a/transcripts/hornet/ping/vindicta_ping_can_heal_astro.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_can_heal_astro.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "9775d38cf418141ece999c3e974e531dbb287585d4902aaaaeda58491475e3b8"
       ],
-      "text": "Holliday, I can hear you.",
+      "text": "Holliday, I can heal you.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "99ab2f0a37867649fd00914d82600bdbfd8285f8847b00e0f3b2be4ae1163680"
       ],
-      "text": "Holiday, I can hear you.",
+      "text": "Holliday, I can heal you.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/hornet/ping/vindicta_ping_can_heal_holliday.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_can_heal_holliday.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "9775d38cf418141ece999c3e974e531dbb287585d4902aaaaeda58491475e3b8"
       ],
-      "text": "Holliday, I can hear you.",
+      "text": "Holliday, I can heal you.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/hornet/ping/vindicta_ping_careful_gigawatt_02.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_careful_gigawatt_02.mp3.json
@@ -22,7 +22,7 @@
       "sha256": [
         "652230ab1ae05578a3010ca4127b6e996063da97ee300f2e18d69eaecddccabf"
       ],
-      "text": "Cancel gigawatts.",
+      "text": "Careful, Seven.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -30,7 +30,7 @@
       "sha256": [
         "0d0a137e3e8d89454fed8a5923c8ede41a4929e684fed38b9c090801d4244c63"
       ],
-      "text": "Cancel gigawatt.",
+      "text": "Careful, Seven.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/hornet/ping/vindicta_ping_careful_gigawatt_02.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_careful_gigawatt_02.mp3.json
@@ -12,23 +12,9 @@
     },
     {
       "sha256": [
+        "0d0a137e3e8d89454fed8a5923c8ede41a4929e684fed38b9c090801d4244c63",
+        "652230ab1ae05578a3010ca4127b6e996063da97ee300f2e18d69eaecddccabf",
         "add751617ca8f6702050fa283178f34cbe2f917f5522ea3cd9f51130ec2b4764"
-      ],
-      "text": "Careful, Seven.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "652230ab1ae05578a3010ca4127b6e996063da97ee300f2e18d69eaecddccabf"
-      ],
-      "text": "Careful, Seven.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "0d0a137e3e8d89454fed8a5923c8ede41a4929e684fed38b9c090801d4244c63"
       ],
       "text": "Careful, Seven.",
       "source": "generated",

--- a/transcripts/hornet/ping/vindicta_ping_green_help_02.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_green_help_02.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "019532a455c2a1574eba955670722a16508ca0d0d6e62cdc7d16be2ab75652d1",
         "811500b979b89fdc2c3591ee4addedf1fa825b6d530a1e56d54c385fb5017d60"
-      ],
-      "text": "Greenwich needs help!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "019532a455c2a1574eba955670722a16508ca0d0d6e62cdc7d16be2ab75652d1"
       ],
       "text": "Greenwich needs help!",
       "source": "generated",

--- a/transcripts/hornet/ping/vindicta_ping_green_help_02.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_green_help_02.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "811500b979b89fdc2c3591ee4addedf1fa825b6d530a1e56d54c385fb5017d60"
       ],
-      "text": "Grenwich needs help!",
+      "text": "Greenwich needs help!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "019532a455c2a1574eba955670722a16508ca0d0d6e62cdc7d16be2ab75652d1"
       ],
-      "text": "Grenich needs help!",
+      "text": "Greenwich needs help!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/hornet/ping/vindicta_ping_lash_under_garage.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_lash_under_garage.mp3.json
@@ -4,6 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "04ed0a9d40b6f70df759e5a163b003439ebb97aa0f922f11a4d121b3176ce181",
+        "26d4b381a348f55d06cc3c5ac92f3304256e250f35b40728c1c5423ae08c3702",
         "8b0c3e52e1f0eece8d9e21f3362976f8010d9031cbc6433d1eeec24b624b1431"
       ],
       "text": "Lash is under the garage!",
@@ -12,25 +14,9 @@
     },
     {
       "sha256": [
-        "04ed0a9d40b6f70df759e5a163b003439ebb97aa0f922f11a4d121b3176ce181"
-      ],
-      "text": "Lash is under the garage.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
         "ef546e5c6a4b75bbe5e41af9c453d86b0c22edcaadbfbac1bbad65b3440112cd"
       ],
       "text": "Last one under the grass.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "26d4b381a348f55d06cc3c5ac92f3304256e250f35b40728c1c5423ae08c3702"
-      ],
-      "text": "Lash is under the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/hornet/ping/vindicta_ping_lash_under_garage.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_lash_under_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "8b0c3e52e1f0eece8d9e21f3362976f8010d9031cbc6433d1eeec24b624b1431"
       ],
-      "text": "Last under the ground.",
+      "text": "Lash is under the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -30,7 +30,7 @@
       "sha256": [
         "26d4b381a348f55d06cc3c5ac92f3304256e250f35b40728c1c5423ae08c3702"
       ],
-      "text": "Blast under the ground!",
+      "text": "Lash is under the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/hornet/ping/vindicta_ping_see_astro_on_bridge.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_see_astro_on_bridge.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "477073a75fde2fee56f247005c8ee7e9570cbee19b9134a3994443fde2259f93",
         "686adad7ebbf1323e787ca4c5bfadad8570c21ee54487cbcee2c5b4cfd43fe86"
-      ],
-      "text": "Holliday's on the bridge.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "477073a75fde2fee56f247005c8ee7e9570cbee19b9134a3994443fde2259f93"
       ],
       "text": "Holliday's on the bridge.",
       "source": "generated",

--- a/transcripts/hornet/ping/vindicta_ping_see_astro_on_bridge.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_see_astro_on_bridge.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "686adad7ebbf1323e787ca4c5bfadad8570c21ee54487cbcee2c5b4cfd43fe86"
       ],
-      "text": "Holiday's celebration.",
+      "text": "Holliday's on the bridge.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "477073a75fde2fee56f247005c8ee7e9570cbee19b9134a3994443fde2259f93"
       ],
-      "text": "Holiday celebration.",
+      "text": "Holliday's on the bridge.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/hornet/ping/vindicta_ping_see_geist_on_bridge.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_see_geist_on_bridge.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "5034ff393430f778e3b4491b48e0ff749891407b2ec519b6b928ee4e7b917a27"
       ],
-      "text": "Guy's is on the bridge.",
+      "text": "Geist is on the bridge.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "8e6bb56ecb866fee1c086237f3bad9817c0507a917d2e178bcb35eac1cb39a3e"
       ],
-      "text": "Guys, he's on the bridge!",
+      "text": "Geist is on the bridge!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -30,7 +30,7 @@
       "sha256": [
         "e2e1068e53234f0a23cbccf97eb938c23b4bacf378b9348c25d1cff92693deee"
       ],
-      "text": "guys, she's on the bridge.",
+      "text": "Geist is on the bridge.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/hornet/ping/vindicta_ping_see_geist_on_bridge.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_see_geist_on_bridge.mp3.json
@@ -12,22 +12,8 @@
     },
     {
       "sha256": [
-        "5034ff393430f778e3b4491b48e0ff749891407b2ec519b6b928ee4e7b917a27"
-      ],
-      "text": "Geist is on the bridge.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "8e6bb56ecb866fee1c086237f3bad9817c0507a917d2e178bcb35eac1cb39a3e"
-      ],
-      "text": "Geist is on the bridge!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "5034ff393430f778e3b4491b48e0ff749891407b2ec519b6b928ee4e7b917a27",
+        "8e6bb56ecb866fee1c086237f3bad9817c0507a917d2e178bcb35eac1cb39a3e",
         "e2e1068e53234f0a23cbccf97eb938c23b4bacf378b9348c25d1cff92693deee"
       ],
       "text": "Geist is on the bridge.",

--- a/transcripts/hornet/ping/vindicta_ping_see_holliday_on_bridge.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_see_holliday_on_bridge.mp3.json
@@ -4,19 +4,12 @@
   "revisions": [
     {
       "sha256": [
-        "686adad7ebbf1323e787ca4c5bfadad8570c21ee54487cbcee2c5b4cfd43fe86"
-      ],
-      "text": "Holliday's on the bridge.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
         "5ba984a970447c923db5c88761602b55f4fa759ba6e5574dec7ea1338491b923",
+        "686adad7ebbf1323e787ca4c5bfadad8570c21ee54487cbcee2c5b4cfd43fe86",
         "9fb10eb68a9085189e77e8886c7e3ae5499ca3601896ba15ced32d638019d734",
         "b7bd30b48944ab8c843af645a44cbe38dc47ae6ccbae15cd27b7d2eb3967972b"
       ],
-      "text": "Holliday's on the bridge!",
+      "text": "Holliday's on the bridge.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/hornet/ping/vindicta_ping_see_holliday_on_bridge.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_see_holliday_on_bridge.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "686adad7ebbf1323e787ca4c5bfadad8570c21ee54487cbcee2c5b4cfd43fe86"
       ],
-      "text": "Holiday's celebration.",
+      "text": "Holliday's on the bridge.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/hornet/ping/vindicta_ping_see_lash_02.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_see_lash_02.mp3.json
@@ -12,16 +12,9 @@
     },
     {
       "sha256": [
+        "5398e003d8a05c87f65b1b20dae06e6c4d788ba31b527783091766da1b556118",
         "a52a35b6edd7db5e2761192503c2ae33cf481619fed44fc82c9ddcaefc75102d",
         "f4d15db130f0a4899915f2c3ecc01f3b4e3ccf175bf7c7326fcbb7229376c235"
-      ],
-      "text": "There's that arrogant bastard!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "5398e003d8a05c87f65b1b20dae06e6c4d788ba31b527783091766da1b556118"
       ],
       "text": "There's that arrogant bastard!",
       "source": "generated",

--- a/transcripts/hornet/ping/vindicta_ping_see_lash_02.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_see_lash_02.mp3.json
@@ -15,7 +15,7 @@
         "a52a35b6edd7db5e2761192503c2ae33cf481619fed44fc82c9ddcaefc75102d",
         "f4d15db130f0a4899915f2c3ecc01f3b4e3ccf175bf7c7326fcbb7229376c235"
       ],
-      "text": "Tears that arrogant bastard!",
+      "text": "There's that arrogant bastard!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -23,7 +23,7 @@
       "sha256": [
         "5398e003d8a05c87f65b1b20dae06e6c4d788ba31b527783091766da1b556118"
       ],
-      "text": "Tear that arrogant bastard!",
+      "text": "There's that arrogant bastard!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/hornet/ping/vindicta_ping_wraith_missing_01.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_wraith_missing_01.mp3.json
@@ -12,15 +12,8 @@
     },
     {
       "sha256": [
+        "7dd8a9e4c7bb60eecf22f52ce99f4ea0d0c60671cfe2040d5df164d52650e9ff",
         "e105375f3aed9ace46e9709a89cc7e123ffcb7bf667ee847c66ce17ec30c3031"
-      ],
-      "text": "Wraith is missing.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "7dd8a9e4c7bb60eecf22f52ce99f4ea0d0c60671cfe2040d5df164d52650e9ff"
       ],
       "text": "Wraith is missing.",
       "source": "generated",

--- a/transcripts/hornet/ping/vindicta_ping_wraith_missing_01.mp3.json
+++ b/transcripts/hornet/ping/vindicta_ping_wraith_missing_01.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "e105375f3aed9ace46e9709a89cc7e123ffcb7bf667ee847c66ce17ec30c3031"
       ],
-      "text": "Race is missing.",
+      "text": "Wraith is missing.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "7dd8a9e4c7bb60eecf22f52ce99f4ea0d0c60671cfe2040d5df164d52650e9ff"
       ],
-      "text": "Grace is missing.",
+      "text": "Wraith is missing.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/inferno/inferno_concerned_03.mp3.json
+++ b/transcripts/inferno/inferno_concerned_03.mp3.json
@@ -13,14 +13,7 @@
     {
       "sha256": [
         "145464e8290c4d4bf1fe383de4404e529031079d35a7ea67a68d93052f44c01d",
-        "552f314a5e7a76de813fc49a78d915cb069525da389ecc68032539b9114e1429"
-      ],
-      "text": "If we don't change things up, we're screwed.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "552f314a5e7a76de813fc49a78d915cb069525da389ecc68032539b9114e1429",
         "a2c4ca4b8793cc97e51280688a5e66c68d32fd7a609185627e9e6861d27bc99a"
       ],
       "text": "If we don't change things up, we're screwed.",

--- a/transcripts/inferno/inferno_concerned_03.mp3.json
+++ b/transcripts/inferno/inferno_concerned_03.mp3.json
@@ -15,7 +15,7 @@
         "145464e8290c4d4bf1fe383de4404e529031079d35a7ea67a68d93052f44c01d",
         "552f314a5e7a76de813fc49a78d915cb069525da389ecc68032539b9114e1429"
       ],
-      "text": "If we don't change things up, we screwed.",
+      "text": "If we don't change things up, we're screwed.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/inferno/inferno_see_money_01.mp3.json
+++ b/transcripts/inferno/inferno_see_money_01.mp3.json
@@ -12,14 +12,7 @@
     },
     {
       "sha256": [
-        "3ea530a6beff9af175eb0830827446f5b2286104b7521aadd876d4c9945b5fb5"
-      ],
-      "text": "There's some souls laying around.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "3ea530a6beff9af175eb0830827446f5b2286104b7521aadd876d4c9945b5fb5",
         "86312ce945d9d737977ebbf1668ae3e34e9e0bd9de1648609c93adf70f8358b2"
       ],
       "text": "There's some souls laying around.",

--- a/transcripts/inferno/inferno_see_money_01.mp3.json
+++ b/transcripts/inferno/inferno_see_money_01.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "3ea530a6beff9af175eb0830827446f5b2286104b7521aadd876d4c9945b5fb5"
       ],
-      "text": "There's some opals laying around.",
+      "text": "There's some souls laying around.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "86312ce945d9d737977ebbf1668ae3e34e9e0bd9de1648609c93adf70f8358b2"
       ],
-      "text": "There's some ovals laying around.",
+      "text": "There's some souls laying around.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/inferno/ping/inferno_ping_astro_almost_respawn.mp3.json
+++ b/transcripts/inferno/ping/inferno_ping_astro_almost_respawn.mp3.json
@@ -12,15 +12,8 @@
     },
     {
       "sha256": [
+        "947a1aeafac487b89266fbebe79da9a3e1c011f48535d5df2b1182151ef6f261",
         "9a287a9c478622ef7c5a743e803c5ebedcf4b31d11fa79692f9e9cfb75c04c15"
-      ],
-      "text": "Holliday is almost back.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "947a1aeafac487b89266fbebe79da9a3e1c011f48535d5df2b1182151ef6f261"
       ],
       "text": "Holliday is almost back.",
       "source": "generated",

--- a/transcripts/inferno/ping/inferno_ping_astro_almost_respawn.mp3.json
+++ b/transcripts/inferno/ping/inferno_ping_astro_almost_respawn.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "8bd5b881267b26ebd807ed9d63e68f2fdc337743e9b5a9665ffe819582ef4cfe"
       ],
-      "text": "Holidays almost back.",
+      "text": "Holliday's almost back.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "9a287a9c478622ef7c5a743e803c5ebedcf4b31d11fa79692f9e9cfb75c04c15"
       ],
-      "text": "The holiday is almost back.",
+      "text": "Holliday is almost back.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/inferno/ping/inferno_ping_careful_kali_03.mp3.json
+++ b/transcripts/inferno/ping/inferno_ping_careful_kali_03.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "0d58af556bc5cb1792c8c84cb0a746cb083344ec84a5a0b5135f8c94ddf36ffa"
       ],
-      "text": "Careful, Calli!",
+      "text": "Careful, Kali!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "1ec9b3b30f00b9713cd97c9cbc943af3129be5399d0774c2429367da5dfa39f3"
       ],
-      "text": "Careful, Callie!",
+      "text": "Careful, Kali!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/inferno/ping/inferno_ping_careful_kali_03.mp3.json
+++ b/transcripts/inferno/ping/inferno_ping_careful_kali_03.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "0d58af556bc5cb1792c8c84cb0a746cb083344ec84a5a0b5135f8c94ddf36ffa"
-      ],
-      "text": "Careful, Kali!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "0d58af556bc5cb1792c8c84cb0a746cb083344ec84a5a0b5135f8c94ddf36ffa",
         "1ec9b3b30f00b9713cd97c9cbc943af3129be5399d0774c2429367da5dfa39f3"
       ],
       "text": "Careful, Kali!",

--- a/transcripts/inferno/ping/inferno_ping_see_wraith_on_roof.mp3.json
+++ b/transcripts/inferno/ping/inferno_ping_see_wraith_on_roof.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "7f8c7f6d008c5e8dd9abe6a144eebb607477a5981f92e7230b8920ba60fe2525"
       ],
-      "text": "Grace on the rooftop!",
+      "text": "Wraith is on the roof!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "1a6a57b0f2389261bfaa8d7fe99208ea6e2196692333a8d8b97cabe7f735edf1"
       ],
-      "text": "Race on the roof!",
+      "text": "Wraith is on the roof!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "dc871faeff9c1381062dcc4908b7484a7f1b051050f88152dc35e1adccea16ff"
       ],
-      "text": "Grace on the roof.",
+      "text": "Wraith is on the roof!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/inferno/ping/inferno_ping_see_wraith_on_roof.mp3.json
+++ b/transcripts/inferno/ping/inferno_ping_see_wraith_on_roof.mp3.json
@@ -4,22 +4,8 @@
   "revisions": [
     {
       "sha256": [
-        "7f8c7f6d008c5e8dd9abe6a144eebb607477a5981f92e7230b8920ba60fe2525"
-      ],
-      "text": "Wraith is on the roof!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "1a6a57b0f2389261bfaa8d7fe99208ea6e2196692333a8d8b97cabe7f735edf1"
-      ],
-      "text": "Wraith is on the roof!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "1a6a57b0f2389261bfaa8d7fe99208ea6e2196692333a8d8b97cabe7f735edf1",
+        "7f8c7f6d008c5e8dd9abe6a144eebb607477a5981f92e7230b8920ba60fe2525",
         "dc871faeff9c1381062dcc4908b7484a7f1b051050f88152dc35e1adccea16ff"
       ],
       "text": "Wraith is on the roof!",

--- a/transcripts/inferno/ping/inferno_ping_with_haze.mp3.json
+++ b/transcripts/inferno/ping/inferno_ping_with_haze.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "010c02e1868a8b1f9da2e1d258646c9bdbf5a13fee9834d3bd0f6205a5f3f7a4"
       ],
-      "text": "I'm with you, Aces.",
+      "text": "I'm with you, Haze.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -15,7 +15,7 @@
         "28e3aae6fa9441730b29838ff2a56822d7c67d0c9b71c0e781db082f790a74aa",
         "b2de76998cd0cf26f851372904acc3e56d5449c7356f9cd6e83a24bab9000e77"
       ],
-      "text": "I'm with you, Ace.",
+      "text": "I'm with you, Haze.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/inferno/ping/inferno_ping_with_haze.mp3.json
+++ b/transcripts/inferno/ping/inferno_ping_with_haze.mp3.json
@@ -4,23 +4,9 @@
   "revisions": [
     {
       "sha256": [
-        "010c02e1868a8b1f9da2e1d258646c9bdbf5a13fee9834d3bd0f6205a5f3f7a4"
-      ],
-      "text": "I'm with you, Haze.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "010c02e1868a8b1f9da2e1d258646c9bdbf5a13fee9834d3bd0f6205a5f3f7a4",
         "28e3aae6fa9441730b29838ff2a56822d7c67d0c9b71c0e781db082f790a74aa",
-        "b2de76998cd0cf26f851372904acc3e56d5449c7356f9cd6e83a24bab9000e77"
-      ],
-      "text": "I'm with you, Haze.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "b2de76998cd0cf26f851372904acc3e56d5449c7356f9cd6e83a24bab9000e77",
         "f82942a30e9e896e9718345a7b725bfd3498faf85973071f388acd38184a407c"
       ],
       "text": "I'm with you, Haze.",

--- a/transcripts/kali/rr_test_19_outnumbered_03.mp3.json
+++ b/transcripts/kali/rr_test_19_outnumbered_03.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "535b45882cbca9f08c99f6ca0924085b770045a052df5984c09340be905da71a"
       ],
-      "text": "Can you play in the Dramalanguage?",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "77448621ba69624acb658d8ad3d6b2bf6c7ac06436fc744b16dcf54bd2565278"
       ],
-      "text": "Can you play the drama language?",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/kali/rr_test_19_outnumbered_03.mp3.json
+++ b/transcripts/kali/rr_test_19_outnumbered_03.mp3.json
@@ -12,14 +12,7 @@
     },
     {
       "sha256": [
-        "535b45882cbca9f08c99f6ca0924085b770045a052df5984c09340be905da71a"
-      ],
-      "text": "",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "535b45882cbca9f08c99f6ca0924085b770045a052df5984c09340be905da71a",
         "77448621ba69624acb658d8ad3d6b2bf6c7ac06436fc744b16dcf54bd2565278"
       ],
       "text": "",

--- a/transcripts/kali/rr_test_19_ping_chrono_missing_01.mp3.json
+++ b/transcripts/kali/rr_test_19_ping_chrono_missing_01.mp3.json
@@ -7,7 +7,7 @@
         "21ef21a4353b64351e56e4ab6bc154443f5681db2f7854df37c5b84c4a27f044",
         "ccb317a5306cad528b93e9093ce622651276afb21b9054691401004dc0117932"
       ],
-      "text": "Crow is missing.",
+      "text": "Chrono is missing.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -15,7 +15,7 @@
       "sha256": [
         "0c5d958366cd00fd6744201aa06804dfda564087b894859f38a2b80b685ab4b9"
       ],
-      "text": "Cow is missing.",
+      "text": "Chrono is missing.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/kali/rr_test_19_ping_chrono_missing_01.mp3.json
+++ b/transcripts/kali/rr_test_19_ping_chrono_missing_01.mp3.json
@@ -4,16 +4,9 @@
   "revisions": [
     {
       "sha256": [
+        "0c5d958366cd00fd6744201aa06804dfda564087b894859f38a2b80b685ab4b9",
         "21ef21a4353b64351e56e4ab6bc154443f5681db2f7854df37c5b84c4a27f044",
         "ccb317a5306cad528b93e9093ce622651276afb21b9054691401004dc0117932"
-      ],
-      "text": "Chrono is missing.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "0c5d958366cd00fd6744201aa06804dfda564087b894859f38a2b80b685ab4b9"
       ],
       "text": "Chrono is missing.",
       "source": "generated",

--- a/transcripts/kali/rr_test_19_ping_see_dynamo_on_roof.mp3.json
+++ b/transcripts/kali/rr_test_19_ping_see_dynamo_on_roof.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "59c234d00574b41383af8844a4afa2a60138ac7256da2d7277b1434c20b871fd"
       ],
-      "text": "I don't need your sympathy, but thanks for the offer.",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "749bbfd254b24310af1f1bb6ddbc75a97ed45a577b10a13877646155e7aa29d3"
       ],
-      "text": "ChatGPT: context: ###\nTranscribe this Deadlock voice line in English exactly. Preserve all spoken words. Do not add commentary or quotation marks. The following JSON contains authoritative Deadlock spellings, terminology, and transcription guidelines. Follow it when applicable: {\"Characters\":[\"Holliday\",\"Shelly Fisher\",\"Geist\",\"Marla\",\"Marlowe\",\"Troubadour\",\"Nashala Dion\",\"Viscous\",\"John Hathorne\",\"Edrick\",\"Captain Murphy\",\"Holliday\",\"Infernus\",\"Kelvin\",\"Abrams\",\"Vindicta\",\"Operative\",\"Bebop\",\"Cadence\",\"Paradox\",\"Dynamo\",\"McGinnis\",\"Lady Geist\",\"Seven\",\"Haze\",\"Krill\",\"Lash\",\"Magician\",\"Mirage\",\"Nano\",\"Grey Talon\",\"Shiv\",\"Slork\",\"Pocket\",\"Ivy\",\"Trapper\",\"Vyper\",\"Viscous\",\"Warden\",\"Wraith\",\"Wrecker\",\"Yamato\",\"Fern\",\"Mina Ha\",\"Doorman\",\"Paige\",\"Rem\",\"Apollo\",\"Graves\",\"Pepper\",\"Silver\",\"Venator\"],\"Groups\":[\"Djinn\"],\"Places\":[\"Ixia\",\"Blackmore\"],\"Abilities\":[\"Ping\"],\"Game Terms\":[\"Mid\",\"Mid-Boss\",\"Gank\",\"Payload\",\"Capture\",\"Control\",\"Escort\"],\"Transcription Guidelines\":[\"Use sentence case for all transcriptions.\",\"Use standard punctuation.\",\"Follow the above spelling for ambiguous names.\",\"Do not include extra whitespace at the beginning or end of transcriptions.\"]}\n###",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "e455c5d21b6b2e2e07f0c13b063e0fe3370d5c05aa894a2074050eb51fe34105"
       ],
-      "text": "context: ###\nTranscribe this Deadlock voice line in English exactly. Preserve all spoken words. Do not add commentary or quotation marks. The following JSON contains authoritative Deadlock spellings, terminology, and transcription guidelines. Follow it when applicable: {\"Characters\":[\"Holliday\",\"Shelly Fisher\",\"Geist\",\"Marla\",\"Marlowe\",\"Troubadour\",\"Nashala Dion\",\"Viscous\",\"John Hathorne\",\"Edrick\",\"Captain Murphy\",\"Holliday\",\"Infernus\",\"Kelvin\",\"Abrams\",\"Vindicta\",\"Operative\",\"Bebop\",\"Cadence\",\"Paradox\",\"Dynamo\",\"McGinnis\",\"Lady Geist\",\"Seven\",\"Haze\",\"Krill\",\"Lash\",\"Magician\",\"Mirage\",\"Nano\",\"Grey Talon\",\"Shiv\",\"Slork\",\"Pocket\",\"Ivy\",\"Trapper\",\"Vyper\",\"Viscous\",\"Warden\",\"Wraith\",\"Wrecker\",\"Yamato\",\"Fern\",\"Mina Ha\",\"Doorman\",\"Paige\",\"Rem\",\"Apollo\",\"Graves\",\"Pepper\",\"Silver\",\"Venator\"],\"Groups\":[\"Djinn\"],\"Places\":[\"Ixia\",\"Blackmore\"],\"Abilities\":[\"Ping\"],\"Game Terms\":[\"Mid\",\"Mid-Boss\",\"Gank\",\"Payload\",\"Capture\",\"Control\",\"Escort\"],\"Transcription Guidelines\":[\"Use sentence case for all transcriptions.\",\"Use standard punctuation.\",\"Follow the above spelling for ambiguous names.\",\"Do not include extra whitespace at the beginning or end of transcriptions.\"]}\n###",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/kali/rr_test_19_ping_see_dynamo_on_roof.mp3.json
+++ b/transcripts/kali/rr_test_19_ping_see_dynamo_on_roof.mp3.json
@@ -4,22 +4,8 @@
   "revisions": [
     {
       "sha256": [
-        "59c234d00574b41383af8844a4afa2a60138ac7256da2d7277b1434c20b871fd"
-      ],
-      "text": "",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "749bbfd254b24310af1f1bb6ddbc75a97ed45a577b10a13877646155e7aa29d3"
-      ],
-      "text": "",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "59c234d00574b41383af8844a4afa2a60138ac7256da2d7277b1434c20b871fd",
+        "749bbfd254b24310af1f1bb6ddbc75a97ed45a577b10a13877646155e7aa29d3",
         "e455c5d21b6b2e2e07f0c13b063e0fe3370d5c05aa894a2074050eb51fe34105"
       ],
       "text": "",

--- a/transcripts/krill/krill_killed_by_shiv_01.mp3.json
+++ b/transcripts/krill/krill_killed_by_shiv_01.mp3.json
@@ -7,7 +7,7 @@
         "31c3742e24e7f8d7b3e2c7bf70bf053612c1d354470fe07b93a5c4860a78c2f9",
         "800278d9774d6eff9f73ae88d65eea95181955eb4bf450276c1ea349994403be"
       ],
-      "text": "I'm sorry, Maurice, I was just distracted by his magnificent quaff.",
+      "text": "I'm sorry, Maurice, I was just distracted by his magnificent coif.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -15,7 +15,7 @@
       "sha256": [
         "15df131a327600c76eaf90a9679b4db14020518be34a82b1ba6dc288fbc848e8"
       ],
-      "text": "I'm sorry, Maurice, I was just distracted by his magnificent quad.",
+      "text": "I'm sorry, Maurice, I was just distracted by his magnificent coif.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/krill/krill_killed_by_shiv_01.mp3.json
+++ b/transcripts/krill/krill_killed_by_shiv_01.mp3.json
@@ -4,16 +4,9 @@
   "revisions": [
     {
       "sha256": [
+        "15df131a327600c76eaf90a9679b4db14020518be34a82b1ba6dc288fbc848e8",
         "31c3742e24e7f8d7b3e2c7bf70bf053612c1d354470fe07b93a5c4860a78c2f9",
         "800278d9774d6eff9f73ae88d65eea95181955eb4bf450276c1ea349994403be"
-      ],
-      "text": "I'm sorry, Maurice, I was just distracted by his magnificent coif.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "15df131a327600c76eaf90a9679b4db14020518be34a82b1ba6dc288fbc848e8"
       ],
       "text": "I'm sorry, Maurice, I was just distracted by his magnificent coif.",
       "source": "generated",

--- a/transcripts/krill/ping/krill_ping_sandeep_under_garage.mp3.json
+++ b/transcripts/krill/ping/krill_ping_sandeep_under_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "c9ac686da14746d3a1911214545bcfb435711591198869898ca19d2d8a79bf73"
       ],
-      "text": "Sanji is under the garage!",
+      "text": "Sandeep is under the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "7db89d897a052fd3ee883c1014d653a4f1ed8ba18572a513c47c6b1df884b936"
       ],
-      "text": "Sandi is under the garage.",
+      "text": "Sandeep is under the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "f144ba83994a1dee6eae657bf42f450bbf52a85721fd5d1e1b8d9a4bf4276497"
       ],
-      "text": "Sanji's under the garage!",
+      "text": "Sandeep's under the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/krill/ping/krill_ping_sandeep_under_garage.mp3.json
+++ b/transcripts/krill/ping/krill_ping_sandeep_under_garage.mp3.json
@@ -4,17 +4,10 @@
   "revisions": [
     {
       "sha256": [
+        "7db89d897a052fd3ee883c1014d653a4f1ed8ba18572a513c47c6b1df884b936",
         "c9ac686da14746d3a1911214545bcfb435711591198869898ca19d2d8a79bf73"
       ],
       "text": "Sandeep is under the garage!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "7db89d897a052fd3ee883c1014d653a4f1ed8ba18572a513c47c6b1df884b936"
-      ],
-      "text": "Sandeep is under the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/krill/ping/krill_ping_saw_hornet.mp3.json
+++ b/transcripts/krill/ping/krill_ping_saw_hornet.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "dfd9a7d6b433924eefc9a3adbf4a269e6ec4d975f42907fdc68211202493d400"
       ],
-      "text": "Hey, so Vindicta!",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "cb1d8157240ff08a250084aa0437f0f2f284b61b0f6fae347a6f0d10ea2ae5fd"
       ],
-      "text": "Hey, Sol Vindicta!",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/krill/ping/krill_ping_saw_hornet.mp3.json
+++ b/transcripts/krill/ping/krill_ping_saw_hornet.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "cb1d8157240ff08a250084aa0437f0f2f284b61b0f6fae347a6f0d10ea2ae5fd",
         "dfd9a7d6b433924eefc9a3adbf4a269e6ec4d975f42907fdc68211202493d400"
-      ],
-      "text": "",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "cb1d8157240ff08a250084aa0437f0f2f284b61b0f6fae347a6f0d10ea2ae5fd"
       ],
       "text": "",
       "source": "generated",

--- a/transcripts/krill/ping/krill_ping_saw_vindicta.mp3.json
+++ b/transcripts/krill/ping/krill_ping_saw_vindicta.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "dfd9a7d6b433924eefc9a3adbf4a269e6ec4d975f42907fdc68211202493d400"
       ],
-      "text": "Hey, so Vindicta!",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "cb1d8157240ff08a250084aa0437f0f2f284b61b0f6fae347a6f0d10ea2ae5fd"
       ],
-      "text": "Hey, Sol Vindicta!",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/krill/ping/krill_ping_saw_vindicta.mp3.json
+++ b/transcripts/krill/ping/krill_ping_saw_vindicta.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "cb1d8157240ff08a250084aa0437f0f2f284b61b0f6fae347a6f0d10ea2ae5fd",
         "dfd9a7d6b433924eefc9a3adbf4a269e6ec4d975f42907fdc68211202493d400"
-      ],
-      "text": "",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "cb1d8157240ff08a250084aa0437f0f2f284b61b0f6fae347a6f0d10ea2ae5fd"
       ],
       "text": "",
       "source": "generated",

--- a/transcripts/lash/lash_catch_hornet_02.mp3.json
+++ b/transcripts/lash/lash_catch_hornet_02.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "a60d420d2942bca0ccf389510130b0f0a613736da11cf5282cdd65120f7af42c"
       ],
-      "text": "Where is your sign-off to?",
+      "text": "Where do you think you're flying off to?",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "0a719e68ce1c50aba53aede1a3002c44de5f33ef37938b886079a71ca80c5d54"
       ],
-      "text": "Where is your sign-off, too?",
+      "text": "Where do you think you're flying off to?",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/lash/lash_catch_hornet_02.mp3.json
+++ b/transcripts/lash/lash_catch_hornet_02.mp3.json
@@ -12,23 +12,9 @@
     },
     {
       "sha256": [
+        "0a719e68ce1c50aba53aede1a3002c44de5f33ef37938b886079a71ca80c5d54",
+        "21686541db9e40afd0c03b12111ea3cc98ccdcc70c722eb23610774840c2b6d6",
         "a60d420d2942bca0ccf389510130b0f0a613736da11cf5282cdd65120f7af42c"
-      ],
-      "text": "Where do you think you're flying off to?",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "0a719e68ce1c50aba53aede1a3002c44de5f33ef37938b886079a71ca80c5d54"
-      ],
-      "text": "Where do you think you're flying off to?",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "21686541db9e40afd0c03b12111ea3cc98ccdcc70c722eb23610774840c2b6d6"
       ],
       "text": "Where do you think you're flying off to?",
       "source": "generated",

--- a/transcripts/lash/lash_select_04.mp3.json
+++ b/transcripts/lash/lash_select_04.mp3.json
@@ -12,23 +12,9 @@
     },
     {
       "sha256": [
+        "651af8ab8de89d9a47019c0bbefb8ba0e9b5eb19f93d1ff72f07ae5fdec713d4",
+        "a0659651bf5e3f4ed73938cfbdc55fbdfc9dfe7339df7153719fc6817ee02890",
         "b83a433084e61ea26ab5a5137a51853d7f3cb3136cf12689cd9816b53bcdde62"
-      ],
-      "text": "A fun little fact: Lash used to do an uppercut. And then I saw Bebop do an uppercut, and I knew right then and there that I would never do one again.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "a0659651bf5e3f4ed73938cfbdc55fbdfc9dfe7339df7153719fc6817ee02890"
-      ],
-      "text": "A fun little fact: Lash used to do an uppercut. And then I saw Bebop do an uppercut, and I knew right then and there that I would never do one again.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "651af8ab8de89d9a47019c0bbefb8ba0e9b5eb19f93d1ff72f07ae5fdec713d4"
       ],
       "text": "A fun little fact: Lash used to do an uppercut. And then I saw Bebop do an uppercut, and I knew right then and there that I would never do one again.",
       "source": "generated",

--- a/transcripts/lash/lash_select_04.mp3.json
+++ b/transcripts/lash/lash_select_04.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "b83a433084e61ea26ab5a5137a51853d7f3cb3136cf12689cd9816b53bcdde62"
       ],
-      "text": "The fun was back, but the last used to do an uppercut. And then I saw Bebop do an uppercut, and I knew right then and there that I would never do one again.",
+      "text": "A fun little fact: Lash used to do an uppercut. And then I saw Bebop do an uppercut, and I knew right then and there that I would never do one again.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "a0659651bf5e3f4ed73938cfbdc55fbdfc9dfe7339df7153719fc6817ee02890"
       ],
-      "text": "The fun was that, the last used to do an uppercut. And then I saw Bebop do an uppercut, and I knew right then and there that I would never do one again.",
+      "text": "A fun little fact: Lash used to do an uppercut. And then I saw Bebop do an uppercut, and I knew right then and there that I would never do one again.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -30,7 +30,7 @@
       "sha256": [
         "651af8ab8de89d9a47019c0bbefb8ba0e9b5eb19f93d1ff72f07ae5fdec713d4"
       ],
-      "text": "A fun little fact, Blast used to do an uppercut. And then I saw Bebop do an uppercut, and I knew right then and there that I would never do one again.",
+      "text": "A fun little fact: Lash used to do an uppercut. And then I saw Bebop do an uppercut, and I knew right then and there that I would never do one again.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/lash/ping/lash_ping_ignore_warden.mp3.json
+++ b/transcripts/lash/ping/lash_ping_ignore_warden.mp3.json
@@ -4,23 +4,9 @@
   "revisions": [
     {
       "sha256": [
+        "7eee2ae016dd4fbb3ca0ed41116d4afcf20244d008a5cd1419b12c305571ad54",
+        "b9a744751772df5793529bd30e0b2d079fb684c7706b8573993cbca3f790c343",
         "fe3d21071184eb9e6d71dc9cf173b1cf0764773f3c41c858f53de786d621f080"
-      ],
-      "text": "Ignore Warden.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "7eee2ae016dd4fbb3ca0ed41116d4afcf20244d008a5cd1419b12c305571ad54"
-      ],
-      "text": "Ignore Warden.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "b9a744751772df5793529bd30e0b2d079fb684c7706b8573993cbca3f790c343"
       ],
       "text": "Ignore Warden.",
       "source": "generated",

--- a/transcripts/lash/ping/lash_ping_ignore_warden.mp3.json
+++ b/transcripts/lash/ping/lash_ping_ignore_warden.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "fe3d21071184eb9e6d71dc9cf173b1cf0764773f3c41c858f53de786d621f080"
       ],
-      "text": "Ignore vomitus.",
+      "text": "Ignore Warden.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "7eee2ae016dd4fbb3ca0ed41116d4afcf20244d008a5cd1419b12c305571ad54"
       ],
-      "text": "Ignore vomitous.",
+      "text": "Ignore Warden.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/lash/ping/lash_ping_with_calico.mp3.json
+++ b/transcripts/lash/ping/lash_ping_with_calico.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "0754cc82c7d64a087157d4fae6a164a9d3e98482f1be60ca725f874b49560934"
       ],
-      "text": "Move you, Calico.",
+      "text": "I'm with you, Calico.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "c81103731ef8341364a632adbc2737229ad713b211ba43c3017300046df73da5"
       ],
-      "text": "Move your calico.",
+      "text": "I'm with you, Calico.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/lash/ping/lash_ping_with_calico.mp3.json
+++ b/transcripts/lash/ping/lash_ping_with_calico.mp3.json
@@ -4,22 +4,8 @@
   "revisions": [
     {
       "sha256": [
-        "2d3eb607327fa82826008e93e91fc0ddfc925d84b929aa11ce53b8b5c190636e"
-      ],
-      "text": "I'm with you, Calico.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "0754cc82c7d64a087157d4fae6a164a9d3e98482f1be60ca725f874b49560934"
-      ],
-      "text": "I'm with you, Calico.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "0754cc82c7d64a087157d4fae6a164a9d3e98482f1be60ca725f874b49560934",
+        "2d3eb607327fa82826008e93e91fc0ddfc925d84b929aa11ce53b8b5c190636e",
         "c81103731ef8341364a632adbc2737229ad713b211ba43c3017300046df73da5"
       ],
       "text": "I'm with you, Calico.",

--- a/transcripts/mirage/ping/mirage_ping_ability3_almost_ready.mp3.json
+++ b/transcripts/mirage/ping/mirage_ping_ability3_almost_ready.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "95b6fbab029b340fe0d0260247c915ce38ba70dfb472e30bbeb0fa182e1786ac"
       ],
-      "text": "This world is almost ready.",
+      "text": "Mark's almost ready.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "7d13e99d55d09267b3354c6a519f7bd3555843f53095a6e2734f961c97904f09"
       ],
-      "text": "This word is almost ready.",
+      "text": "Mark's almost ready.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/mirage/ping/mirage_ping_ability3_almost_ready.mp3.json
+++ b/transcripts/mirage/ping/mirage_ping_ability3_almost_ready.mp3.json
@@ -4,23 +4,9 @@
   "revisions": [
     {
       "sha256": [
+        "7d13e99d55d09267b3354c6a519f7bd3555843f53095a6e2734f961c97904f09",
+        "86e14f436f0621a95ea21d9b0b79dc12c3eb489fce0b5635047578dcceab1094",
         "95b6fbab029b340fe0d0260247c915ce38ba70dfb472e30bbeb0fa182e1786ac"
-      ],
-      "text": "Mark's almost ready.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "7d13e99d55d09267b3354c6a519f7bd3555843f53095a6e2734f961c97904f09"
-      ],
-      "text": "Mark's almost ready.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "86e14f436f0621a95ea21d9b0b79dc12c3eb489fce0b5635047578dcceab1094"
       ],
       "text": "Mark's almost ready",
       "source": "official"

--- a/transcripts/mirage/ping/mirage_ping_attack_lash.mp3.json
+++ b/transcripts/mirage/ping/mirage_ping_attack_lash.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "acb32144d581d2bb322b6ea33da21673a8a687ecdc5cef0088a72227b4896755"
       ],
-      "text": "The stick of lash.",
+      "text": "Attack Lash.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "969250be0893f774173fb66727c6e043c8ebdcda08a0e1434172484c85ec1b35"
       ],
-      "text": "The stick of flash!",
+      "text": "Attack Lash.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/mirage/ping/mirage_ping_attack_lash.mp3.json
+++ b/transcripts/mirage/ping/mirage_ping_attack_lash.mp3.json
@@ -12,15 +12,8 @@
     },
     {
       "sha256": [
+        "969250be0893f774173fb66727c6e043c8ebdcda08a0e1434172484c85ec1b35",
         "acb32144d581d2bb322b6ea33da21673a8a687ecdc5cef0088a72227b4896755"
-      ],
-      "text": "Attack Lash.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "969250be0893f774173fb66727c6e043c8ebdcda08a0e1434172484c85ec1b35"
       ],
       "text": "Attack Lash.",
       "source": "generated",

--- a/transcripts/mirage/ping/mirage_ping_see_lash_on_roof.mp3.json
+++ b/transcripts/mirage/ping/mirage_ping_see_lash_on_roof.mp3.json
@@ -12,15 +12,8 @@
     },
     {
       "sha256": [
+        "c17410f6e0ab2a4bcba53ab3f81b67c804d118749a4298b4fbe40a4f2a4c5791",
         "fac5d6cf5fe3cfb296dbdf5a4e65082575fedf6ecfc13886e8b288073f79d843"
-      ],
-      "text": "Lash is on the roof.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "c17410f6e0ab2a4bcba53ab3f81b67c804d118749a4298b4fbe40a4f2a4c5791"
       ],
       "text": "Lash is on the roof.",
       "source": "generated",

--- a/transcripts/mirage/ping/mirage_ping_see_lash_on_roof.mp3.json
+++ b/transcripts/mirage/ping/mirage_ping_see_lash_on_roof.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "fac5d6cf5fe3cfb296dbdf5a4e65082575fedf6ecfc13886e8b288073f79d843"
       ],
-      "text": "La fusion de rufe.",
+      "text": "Lash is on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "c17410f6e0ab2a4bcba53ab3f81b67c804d118749a4298b4fbe40a4f2a4c5791"
       ],
-      "text": "La fusion de ruf.",
+      "text": "Lash is on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/mirage/ping/mirage_ping_see_wraith_02.mp3.json
+++ b/transcripts/mirage/ping/mirage_ping_see_wraith_02.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "ccbd3a9c0bea9ee9a3f9fd039038c39239b60db7d0a420ba080947ea25b07129"
       ],
-      "text": "I don't think Rafe is looking to pick a card.",
+      "text": "I don't think Wraith is looking to pick a card.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "018ecc3627a7fdf62eeec35bdf74091ee987be052482bd71ad8e4f9e9c65a27e"
       ],
-      "text": "I don't think Raze is looking to pick a card.",
+      "text": "I don't think Wraith is looking to pick a card.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/mirage/ping/mirage_ping_see_wraith_02.mp3.json
+++ b/transcripts/mirage/ping/mirage_ping_see_wraith_02.mp3.json
@@ -12,15 +12,8 @@
     },
     {
       "sha256": [
+        "018ecc3627a7fdf62eeec35bdf74091ee987be052482bd71ad8e4f9e9c65a27e",
         "ccbd3a9c0bea9ee9a3f9fd039038c39239b60db7d0a420ba080947ea25b07129"
-      ],
-      "text": "I don't think Wraith is looking to pick a card.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "018ecc3627a7fdf62eeec35bdf74091ee987be052482bd71ad8e4f9e9c65a27e"
       ],
       "text": "I don't think Wraith is looking to pick a card.",
       "source": "generated",

--- a/transcripts/nano/calico_concerned_05.mp3.json
+++ b/transcripts/nano/calico_concerned_05.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "7040103e61fa0162a4d5b10118a1da38697216cb28945f9284f5bfd30466ebba"
-      ],
-      "text": "",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "7040103e61fa0162a4d5b10118a1da38697216cb28945f9284f5bfd30466ebba",
         "c711fa1e2d5070115181f33ef445f0b91f25230059f8a903768f6c7aecab8a50"
       ],
       "text": "",

--- a/transcripts/nano/calico_concerned_05.mp3.json
+++ b/transcripts/nano/calico_concerned_05.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "7040103e61fa0162a4d5b10118a1da38697216cb28945f9284f5bfd30466ebba"
       ],
-      "text": "I will give up the light of them.",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "c711fa1e2d5070115181f33ef445f0b91f25230059f8a903768f6c7aecab8a50"
       ],
-      "text": "I will give up at the light of them.",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/nano/ping/calico_ping_cadence_on_top_of_mid.mp3.json
+++ b/transcripts/nano/ping/calico_ping_cadence_on_top_of_mid.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "2a539e848f876e2bc61321d2c88565b13c5f6308ae671a168702048884d56018"
-      ],
-      "text": "Cadence's on top of mid.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "2a539e848f876e2bc61321d2c88565b13c5f6308ae671a168702048884d56018",
         "bca3bf8b1a3233ad15f7680bc41ce4b7b71ae37853146bc4d0486cc937b9837a"
       ],
       "text": "Cadence's on top of mid.",

--- a/transcripts/nano/ping/calico_ping_cadence_on_top_of_mid.mp3.json
+++ b/transcripts/nano/ping/calico_ping_cadence_on_top_of_mid.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "2a539e848f876e2bc61321d2c88565b13c5f6308ae671a168702048884d56018"
       ],
-      "text": "Pain's on top of mid.",
+      "text": "Cadence's on top of mid.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "bca3bf8b1a3233ad15f7680bc41ce4b7b71ae37853146bc4d0486cc937b9837a"
       ],
-      "text": "Pins on top of mid.",
+      "text": "Cadence's on top of mid.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/nano/ping/calico_ping_pocket_under_garage.mp3.json
+++ b/transcripts/nano/ping/calico_ping_pocket_under_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "787b263003864dcaf0ad6df7a63da51a34cb53b2c56ca325b0b931b4e246f722"
       ],
-      "text": "Cook is under the garage.",
+      "text": "Pocket is under the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "76d9ba083622fdda14ac1d6c7857ba161e9efb4155dac73838dae36a9a3fdeac"
       ],
-      "text": "Cookie's under the garage.",
+      "text": "Pocket's under the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/nano/ping/calico_ping_see_orion_on_roof.mp3.json
+++ b/transcripts/nano/ping/calico_ping_see_orion_on_roof.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "35779709c1d2715ea263c5082793e8228c96d1b41a2356a0b689a3f56243618a",
         "4c8f53e1624896332d6b8a21458b858c05681416531252e1b64e7f6902cd38b8"
-      ],
-      "text": "Grey Talon's on the roof!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "35779709c1d2715ea263c5082793e8228c96d1b41a2356a0b689a3f56243618a"
       ],
       "text": "Grey Talon's on the roof!",
       "source": "generated",

--- a/transcripts/nano/ping/calico_ping_see_orion_on_roof.mp3.json
+++ b/transcripts/nano/ping/calico_ping_see_orion_on_roof.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "4c8f53e1624896332d6b8a21458b858c05681416531252e1b64e7f6902cd38b8"
       ],
-      "text": "rinds on the roof!",
+      "text": "Grey Talon's on the roof!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "35779709c1d2715ea263c5082793e8228c96d1b41a2356a0b689a3f56243618a"
       ],
-      "text": "Grinds on the roof!",
+      "text": "Grey Talon's on the roof!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/nano/ping/calico_ping_with_warden.mp3.json
+++ b/transcripts/nano/ping/calico_ping_with_warden.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "47c4d625199131c35dc9c1e3200db42f35208544bb6d62a706e3050cfe25e6e6",
         "a402d1fbf7d8a23d5b9f2d5947c34cd1acbf9daf847455488bd41059eead50ad"
-      ],
-      "text": "I'm with you, Warden.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "47c4d625199131c35dc9c1e3200db42f35208544bb6d62a706e3050cfe25e6e6"
       ],
       "text": "I'm with you, Warden.",
       "source": "generated",

--- a/transcripts/nano/ping/calico_ping_with_warden.mp3.json
+++ b/transcripts/nano/ping/calico_ping_with_warden.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "a402d1fbf7d8a23d5b9f2d5947c34cd1acbf9daf847455488bd41059eead50ad"
       ],
-      "text": "The midwarden.",
+      "text": "I'm with you, Warden.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "47c4d625199131c35dc9c1e3200db42f35208544bb6d62a706e3050cfe25e6e6"
       ],
-      "text": "The midy warden.",
+      "text": "I'm with you, Warden.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/orion/ping/orion_ping_with_krill.mp3.json
+++ b/transcripts/orion/ping/orion_ping_with_krill.mp3.json
@@ -12,14 +12,7 @@
     },
     {
       "sha256": [
-        "3f7c98543262566529b09116a089cf06ab299292cd26348edd22f8b3beeaafe8"
-      ],
-      "text": "I'm with you, Krill.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "3f7c98543262566529b09116a089cf06ab299292cd26348edd22f8b3beeaafe8",
         "7222f7369b83d99fc45eb5ffd45033b5827e518e88c71095d13b80091c1b392c"
       ],
       "text": "I'm with you, Krill.",

--- a/transcripts/orion/ping/orion_ping_with_krill.mp3.json
+++ b/transcripts/orion/ping/orion_ping_with_krill.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "3f7c98543262566529b09116a089cf06ab299292cd26348edd22f8b3beeaafe8"
       ],
-      "text": "How was you, Krill?",
+      "text": "I'm with you, Krill.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "7222f7369b83d99fc45eb5ffd45033b5827e518e88c71095d13b80091c1b392c"
       ],
-      "text": "How was your krill?",
+      "text": "I'm with you, Krill.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/orion/ping/orion_ping_yamato_was_here.mp3.json
+++ b/transcripts/orion/ping/orion_ping_yamato_was_here.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "012fe74a87786d51638b5c4e39095507c34adae149e8a976b19811380237d09e"
       ],
-      "text": "Yama Joe is here.",
+      "text": "Yamato was here.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -22,7 +22,7 @@
       "sha256": [
         "6b280728521d461d87c20b6678f1945a98c5595c0e9ce05ada410feb27ef6601"
       ],
-      "text": "Yamato is here.",
+      "text": "Yamato was here.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -30,7 +30,7 @@
       "sha256": [
         "1b9163ddcbdbf4dc17ebe71b2281604c83dfccaa0159051c0577e4e9f7d79680"
       ],
-      "text": "Yamato is here!",
+      "text": "Yamato was here.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/orion/ping/orion_ping_yamato_was_here.mp3.json
+++ b/transcripts/orion/ping/orion_ping_yamato_was_here.mp3.json
@@ -12,23 +12,9 @@
     },
     {
       "sha256": [
-        "012fe74a87786d51638b5c4e39095507c34adae149e8a976b19811380237d09e"
-      ],
-      "text": "Yamato was here.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "012fe74a87786d51638b5c4e39095507c34adae149e8a976b19811380237d09e",
+        "1b9163ddcbdbf4dc17ebe71b2281604c83dfccaa0159051c0577e4e9f7d79680",
         "6b280728521d461d87c20b6678f1945a98c5595c0e9ce05ada410feb27ef6601"
-      ],
-      "text": "Yamato was here.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "1b9163ddcbdbf4dc17ebe71b2281604c83dfccaa0159051c0577e4e9f7d79680"
       ],
       "text": "Yamato was here.",
       "source": "generated",

--- a/transcripts/paradox/ping/paradox_ping_attack_viscous.mp3.json
+++ b/transcripts/paradox/ping/paradox_ping_attack_viscous.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "b599222c7a8f806a5aea612e150cbed2b013234c6cfb2bdcd879638c324ace69",
         "cf56ca7a3a34e2657e4092aea8d5dbeb8263e34d0f7ee0ed8477625a40e301db"
-      ],
-      "text": "",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "b599222c7a8f806a5aea612e150cbed2b013234c6cfb2bdcd879638c324ace69"
       ],
       "text": "",
       "source": "generated",

--- a/transcripts/paradox/ping/paradox_ping_attack_viscous.mp3.json
+++ b/transcripts/paradox/ping/paradox_ping_attack_viscous.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "cf56ca7a3a34e2657e4092aea8d5dbeb8263e34d0f7ee0ed8477625a40e301db"
       ],
-      "text": "That's a good biscuit.",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "b599222c7a8f806a5aea612e150cbed2b013234c6cfb2bdcd879638c324ace69"
       ],
-      "text": "Let's take out Viscous!",
+      "text": "",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/paradox/ping/paradox_ping_cadence_under_garage.mp3.json
+++ b/transcripts/paradox/ping/paradox_ping_cadence_under_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "58ba91d2390407652b2a97e53c90444752120aee965042b239fe46fb94353b48"
       ],
-      "text": "Cadence is under the gauge!",
+      "text": "Cadence is under the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/paradox/ping/paradox_ping_cadence_under_garage.mp3.json
+++ b/transcripts/paradox/ping/paradox_ping_cadence_under_garage.mp3.json
@@ -4,17 +4,10 @@
   "revisions": [
     {
       "sha256": [
-        "58ba91d2390407652b2a97e53c90444752120aee965042b239fe46fb94353b48"
-      ],
-      "text": "Cadence is under the garage!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "58ba91d2390407652b2a97e53c90444752120aee965042b239fe46fb94353b48",
         "8f1bd4fb0f7033b6dc274855681b0c5bb28b1e8e1dcc67e8e98f6b5b3e079146"
       ],
-      "text": "Cadence is under the garage.",
+      "text": "Cadence is under the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/paradox/ping/paradox_ping_haze_on_top_of_mid.mp3.json
+++ b/transcripts/paradox/ping/paradox_ping_haze_on_top_of_mid.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "e52bc115b93f58507534b6f0b5b75cde9a4daff7d246f8ac55aceb5d82fc3146"
       ],
-      "text": "Stay on top of mid!",
+      "text": "Haze is on top of mid!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "946dedaf3b1e92d1343323361d9b9d41e1d14394097825fb78045f08e147b4e7"
       ],
-      "text": "Haze's on top of mid!",
+      "text": "Haze is on top of mid!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/paradox/ping/paradox_ping_haze_on_top_of_mid.mp3.json
+++ b/transcripts/paradox/ping/paradox_ping_haze_on_top_of_mid.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "946dedaf3b1e92d1343323361d9b9d41e1d14394097825fb78045f08e147b4e7",
         "e52bc115b93f58507534b6f0b5b75cde9a4daff7d246f8ac55aceb5d82fc3146"
-      ],
-      "text": "Haze is on top of mid!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "946dedaf3b1e92d1343323361d9b9d41e1d14394097825fb78045f08e147b4e7"
       ],
       "text": "Haze is on top of mid!",
       "source": "generated",

--- a/transcripts/paradox/ping/paradox_ping_see_wraith_on_roof.mp3.json
+++ b/transcripts/paradox/ping/paradox_ping_see_wraith_on_roof.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "ff309cfe806ec3ef62166cf8ccd4402391d3ffe36c06e3a48d8a93c31fbf187f"
       ],
-      "text": "Race on the roof.",
+      "text": "Wraith is on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "a1e5443feb7498602c784ee1804205d6e42d234bffcdcfa743066f9bd69f2fae"
       ],
-      "text": "Wraith's on the roof.",
+      "text": "Wraith is on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/paradox/ping/paradox_ping_see_wraith_on_roof.mp3.json
+++ b/transcripts/paradox/ping/paradox_ping_see_wraith_on_roof.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "a1e5443feb7498602c784ee1804205d6e42d234bffcdcfa743066f9bd69f2fae",
         "ff309cfe806ec3ef62166cf8ccd4402391d3ffe36c06e3a48d8a93c31fbf187f"
-      ],
-      "text": "Wraith is on the roof.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "a1e5443feb7498602c784ee1804205d6e42d234bffcdcfa743066f9bd69f2fae"
       ],
       "text": "Wraith is on the roof.",
       "source": "generated",

--- a/transcripts/paradox/ping/paradox_ping_yamato_on_top_of_garage.mp3.json
+++ b/transcripts/paradox/ping/paradox_ping_yamato_on_top_of_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "5fd63995a24f991a61ae1e9f13952a9b7759a62932c5c41746ae66d3787bf450"
       ],
-      "text": "Yamato's on top of the carriage!",
+      "text": "Yamato's on top of the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "11acb1b65284d2fc9939ad39922b27c050160598d8068d45faa18b64fa9f160b"
       ],
-      "text": "Yamato's on top of the garage!",
+      "text": "Yamato is on top of the garage!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/pocket/ping/pocket_ping_see_forge_on_roof.mp3.json
+++ b/transcripts/pocket/ping/pocket_ping_see_forge_on_roof.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "5ce180035f30a4e56896bcd5e7bbffb3d112b96f1eb9547fc3fb250c90175a0e"
-      ],
-      "text": "McGinnis is on the roof.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "5ce180035f30a4e56896bcd5e7bbffb3d112b96f1eb9547fc3fb250c90175a0e",
         "65f659d31ae55deb8cf900ca22cd3aeec6086c68c7306af367e29b3f67b84221"
       ],
       "text": "McGinnis is on the roof.",

--- a/transcripts/pocket/ping/pocket_ping_see_forge_on_roof.mp3.json
+++ b/transcripts/pocket/ping/pocket_ping_see_forge_on_roof.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "5ce180035f30a4e56896bcd5e7bbffb3d112b96f1eb9547fc3fb250c90175a0e"
       ],
-      "text": "The killist is on the roof.",
+      "text": "McGinnis is on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "65f659d31ae55deb8cf900ca22cd3aeec6086c68c7306af367e29b3f67b84221"
       ],
-      "text": "The kill list is on the roof.",
+      "text": "McGinnis is on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/pocket/ping/pocket_ping_see_mcginnis_on_roof.mp3.json
+++ b/transcripts/pocket/ping/pocket_ping_see_mcginnis_on_roof.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "5ce180035f30a4e56896bcd5e7bbffb3d112b96f1eb9547fc3fb250c90175a0e"
-      ],
-      "text": "McGinnis is on the roof.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "5ce180035f30a4e56896bcd5e7bbffb3d112b96f1eb9547fc3fb250c90175a0e",
         "65f659d31ae55deb8cf900ca22cd3aeec6086c68c7306af367e29b3f67b84221"
       ],
       "text": "McGinnis is on the roof.",

--- a/transcripts/pocket/ping/pocket_ping_see_mcginnis_on_roof.mp3.json
+++ b/transcripts/pocket/ping/pocket_ping_see_mcginnis_on_roof.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "5ce180035f30a4e56896bcd5e7bbffb3d112b96f1eb9547fc3fb250c90175a0e"
       ],
-      "text": "The killist is on the roof.",
+      "text": "McGinnis is on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "65f659d31ae55deb8cf900ca22cd3aeec6086c68c7306af367e29b3f67b84221"
       ],
-      "text": "The kill list is on the roof.",
+      "text": "McGinnis is on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/pocket/ping/pocket_ping_wraith_on_top_of_garage.mp3.json
+++ b/transcripts/pocket/ping/pocket_ping_wraith_on_top_of_garage.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "efa93df1034988622298225e267cd1acaaf1086d514a8223ca00a6dd24c531a1",
         "fd9c0706b5a3d8adfbeb5356a644bebdfe2123af1e8512371bf98e768865de91"
-      ],
-      "text": "Wraith is on top of the garage.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "efa93df1034988622298225e267cd1acaaf1086d514a8223ca00a6dd24c531a1"
       ],
       "text": "Wraith is on top of the garage.",
       "source": "generated",

--- a/transcripts/pocket/ping/pocket_ping_wraith_on_top_of_garage.mp3.json
+++ b/transcripts/pocket/ping/pocket_ping_wraith_on_top_of_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "fd9c0706b5a3d8adfbeb5356a644bebdfe2123af1e8512371bf98e768865de91"
       ],
-      "text": "Race is on top of the garage.",
+      "text": "Wraith is on top of the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "efa93df1034988622298225e267cd1acaaf1086d514a8223ca00a6dd24c531a1"
       ],
-      "text": "Grace is on top of the garage.",
+      "text": "Wraith is on top of the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/shiv/ping/shiv_ping_see_sandeep_on_bridge.mp3.json
+++ b/transcripts/shiv/ping/shiv_ping_see_sandeep_on_bridge.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "5c15c395c29e1310db866e8496be1c9a6062bee271a88d058dc1338f69822748"
       ],
-      "text": "City's on the bridge.",
+      "text": "Sandeep's on the bridge.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "749aedf973a115b1039b06965a80dd7ea42bafd81a6839c2584696878ce44872"
       ],
-      "text": "City on the bridge.",
+      "text": "Sandeep is on the bridge.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/shiv/shiv_use_ability_refresher_01.mp3.json
+++ b/transcripts/shiv/shiv_use_ability_refresher_01.mp3.json
@@ -4,23 +4,9 @@
   "revisions": [
     {
       "sha256": [
+        "54e899de6d701ec1cdf9a0f5dc5a1793d957d719fe8d5ea864415a045ddc4d9d",
+        "71553d8b531c34f9ac8c7f3a76351008f5af7ccc05dffe26e022c09e2db38729",
         "df4152c346b15e21976cc1042253125c0b68463ab89d0b8027017c2e16d4cbb1"
-      ],
-      "text": "Refreshing.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "54e899de6d701ec1cdf9a0f5dc5a1793d957d719fe8d5ea864415a045ddc4d9d"
-      ],
-      "text": "Refreshing.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "71553d8b531c34f9ac8c7f3a76351008f5af7ccc05dffe26e022c09e2db38729"
       ],
       "text": "Refreshing!",
       "source": "official"

--- a/transcripts/shiv/shiv_use_ability_refresher_01.mp3.json
+++ b/transcripts/shiv/shiv_use_ability_refresher_01.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "df4152c346b15e21976cc1042253125c0b68463ab89d0b8027017c2e16d4cbb1"
       ],
-      "text": "The first phrase.",
+      "text": "Refreshing.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "54e899de6d701ec1cdf9a0f5dc5a1793d957d719fe8d5ea864415a045ddc4d9d"
       ],
-      "text": "The first phase.",
+      "text": "Refreshing.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/slork/ping/rr_test_26_ping_see_akimbo_on_bridge.mp3.json
+++ b/transcripts/slork/ping/rr_test_26_ping_see_akimbo_on_bridge.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "5021d898402c5ff5f852052bf0767537a5e78bd80201c6c164f1c6863bdabed9"
       ],
-      "text": "The kimbo is on the bridge.",
+      "text": "Akimbo is on the bridge.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "ee7ee9c684fbce4cab96ba3bc006a443969393f2a1674b753ef05bf0d6ae973d"
       ],
-      "text": "The Kimbo's on the bridge.",
+      "text": "Akimbo's on the bridge.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/slork/ping/rr_test_26_ping_see_zealot_on_roof.mp3.json
+++ b/transcripts/slork/ping/rr_test_26_ping_see_zealot_on_roof.mp3.json
@@ -14,7 +14,7 @@
       "sha256": [
         "65a38171d09c99c401360e4643392f08253e0fc454d11d352ce4ae3b8c66875f"
       ],
-      "text": "Zelot's on the roof.",
+      "text": "Zealot's on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/slork/ping/rr_test_26_ping_see_zealot_on_roof.mp3.json
+++ b/transcripts/slork/ping/rr_test_26_ping_see_zealot_on_roof.mp3.json
@@ -4,17 +4,10 @@
   "revisions": [
     {
       "sha256": [
+        "65a38171d09c99c401360e4643392f08253e0fc454d11d352ce4ae3b8c66875f",
         "d6b1e8c34c8ef89796f3dd99f622409aca2c31e3c315839251da68de6a28c359"
       ],
       "text": "Zealots on the roof.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "65a38171d09c99c401360e4643392f08253e0fc454d11d352ce4ae3b8c66875f"
-      ],
-      "text": "Zealot's on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/synth/ping/pocket_ping_see_forge_on_roof.mp3.json
+++ b/transcripts/synth/ping/pocket_ping_see_forge_on_roof.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "5ce180035f30a4e56896bcd5e7bbffb3d112b96f1eb9547fc3fb250c90175a0e"
-      ],
-      "text": "McGinnis is on the roof.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "5ce180035f30a4e56896bcd5e7bbffb3d112b96f1eb9547fc3fb250c90175a0e",
         "65f659d31ae55deb8cf900ca22cd3aeec6086c68c7306af367e29b3f67b84221"
       ],
       "text": "McGinnis is on the roof.",

--- a/transcripts/synth/ping/pocket_ping_see_forge_on_roof.mp3.json
+++ b/transcripts/synth/ping/pocket_ping_see_forge_on_roof.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "5ce180035f30a4e56896bcd5e7bbffb3d112b96f1eb9547fc3fb250c90175a0e"
       ],
-      "text": "The killist is on the roof.",
+      "text": "McGinnis is on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "65f659d31ae55deb8cf900ca22cd3aeec6086c68c7306af367e29b3f67b84221"
       ],
-      "text": "The kill list is on the roof.",
+      "text": "McGinnis is on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/synth/ping/pocket_ping_see_mcginnis_on_roof.mp3.json
+++ b/transcripts/synth/ping/pocket_ping_see_mcginnis_on_roof.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "5ce180035f30a4e56896bcd5e7bbffb3d112b96f1eb9547fc3fb250c90175a0e"
-      ],
-      "text": "McGinnis is on the roof.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "5ce180035f30a4e56896bcd5e7bbffb3d112b96f1eb9547fc3fb250c90175a0e",
         "65f659d31ae55deb8cf900ca22cd3aeec6086c68c7306af367e29b3f67b84221"
       ],
       "text": "McGinnis is on the roof.",

--- a/transcripts/synth/ping/pocket_ping_see_mcginnis_on_roof.mp3.json
+++ b/transcripts/synth/ping/pocket_ping_see_mcginnis_on_roof.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "5ce180035f30a4e56896bcd5e7bbffb3d112b96f1eb9547fc3fb250c90175a0e"
       ],
-      "text": "The killist is on the roof.",
+      "text": "McGinnis is on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "65f659d31ae55deb8cf900ca22cd3aeec6086c68c7306af367e29b3f67b84221"
       ],
-      "text": "The kill list is on the roof.",
+      "text": "McGinnis is on the roof.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/synth/ping/pocket_ping_wraith_on_top_of_garage.mp3.json
+++ b/transcripts/synth/ping/pocket_ping_wraith_on_top_of_garage.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "efa93df1034988622298225e267cd1acaaf1086d514a8223ca00a6dd24c531a1",
         "fd9c0706b5a3d8adfbeb5356a644bebdfe2123af1e8512371bf98e768865de91"
-      ],
-      "text": "Wraith is on top of the garage.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "efa93df1034988622298225e267cd1acaaf1086d514a8223ca00a6dd24c531a1"
       ],
       "text": "Wraith is on top of the garage.",
       "source": "generated",

--- a/transcripts/synth/ping/pocket_ping_wraith_on_top_of_garage.mp3.json
+++ b/transcripts/synth/ping/pocket_ping_wraith_on_top_of_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "fd9c0706b5a3d8adfbeb5356a644bebdfe2123af1e8512371bf98e768865de91"
       ],
-      "text": "Race is on top of the garage.",
+      "text": "Wraith is on top of the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "efa93df1034988622298225e267cd1acaaf1086d514a8223ca00a6dd24c531a1"
       ],
-      "text": "Grace is on top of the garage.",
+      "text": "Wraith is on top of the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/t1_guardians/guardian_test_04/rr_guardian_test_04_idol_delviery_01.mp3.json
+++ b/transcripts/t1_guardians/guardian_test_04/rr_guardian_test_04_idol_delviery_01.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "57ccdf285a1e0be667596f081f4b9cf08ac84e0ed1412799af9416da9651ee98"
       ],
-      "text": "Bring the aisle over here!",
+      "text": "Bring the idol over here!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -15,7 +15,7 @@
         "b790b70ced5bbf7d24422b7a70917f5668214585810fd00e1e6953056cc53e8e",
         "bae634391a7fc81407898e9bc224e4a37ed5c8fbe0fcf18be231d3c899abd4bb"
       ],
-      "text": "Bring the Isle over here!",
+      "text": "Bring the idol over here!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/t1_guardians/guardian_test_04/rr_guardian_test_04_idol_delviery_01.mp3.json
+++ b/transcripts/t1_guardians/guardian_test_04/rr_guardian_test_04_idol_delviery_01.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "57ccdf285a1e0be667596f081f4b9cf08ac84e0ed1412799af9416da9651ee98"
-      ],
-      "text": "Bring the idol over here!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "57ccdf285a1e0be667596f081f4b9cf08ac84e0ed1412799af9416da9651ee98",
         "b790b70ced5bbf7d24422b7a70917f5668214585810fd00e1e6953056cc53e8e",
         "bae634391a7fc81407898e9bc224e4a37ed5c8fbe0fcf18be231d3c899abd4bb"
       ],

--- a/transcripts/tengu/ivy_ally_orion_missile_stops_ult_03.mp3.json
+++ b/transcripts/tengu/ivy_ally_orion_missile_stops_ult_03.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "6f0fd3fd1f4f2ce683f80ca6e86488a38f72071860baadf9d66e8ae2ebfab183"
-      ],
-      "text": "Thanks, Grey Talon, wherever you are.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "6f0fd3fd1f4f2ce683f80ca6e86488a38f72071860baadf9d66e8ae2ebfab183",
         "86f009c586cc1e52be95397cab9f71a9f5ed84b2995886206a33c95a0bd500d5"
       ],
       "text": "Thanks, Grey Talon, wherever you are.",

--- a/transcripts/tengu/ivy_ally_orion_missile_stops_ult_03.mp3.json
+++ b/transcripts/tengu/ivy_ally_orion_missile_stops_ult_03.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "6f0fd3fd1f4f2ce683f80ca6e86488a38f72071860baadf9d66e8ae2ebfab183"
       ],
-      "text": "Thanks, great darling, wherever you are.",
+      "text": "Thanks, Grey Talon, wherever you are.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "86f009c586cc1e52be95397cab9f71a9f5ed84b2995886206a33c95a0bd500d5"
       ],
-      "text": "Thanks, great dalin, wherever you are.",
+      "text": "Thanks, Grey Talon, wherever you are.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/tengu/ping/ivy_ping_bebop_almost_respawn.mp3.json
+++ b/transcripts/tengu/ping/ivy_ping_bebop_almost_respawn.mp3.json
@@ -4,17 +4,10 @@
   "revisions": [
     {
       "sha256": [
-        "aa01c75b502859b3cea0694a01e3935e34973fc535ac6d8016f8d1af4226ecb9"
-      ],
-      "text": "Bebop is almost back!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "aa01c75b502859b3cea0694a01e3935e34973fc535ac6d8016f8d1af4226ecb9",
         "e9b379539589cebc1cfd0a4f66a230ce0b1b91f946f2c35eb437359eea9d16f4"
       ],
-      "text": "Bebop is almost back.",
+      "text": "Bebop is almost back!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/tengu/ping/ivy_ping_bebop_almost_respawn.mp3.json
+++ b/transcripts/tengu/ping/ivy_ping_bebop_almost_respawn.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "aa01c75b502859b3cea0694a01e3935e34973fc535ac6d8016f8d1af4226ecb9"
       ],
-      "text": "Beepop is almost back!",
+      "text": "Bebop is almost back!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "e9b379539589cebc1cfd0a4f66a230ce0b1b91f946f2c35eb437359eea9d16f4"
       ],
-      "text": "BeepBop is almost back.",
+      "text": "Bebop is almost back.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/wraith/ping/wraith_ping_atlas_missing_01.mp3.json
+++ b/transcripts/wraith/ping/wraith_ping_atlas_missing_01.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "1b612fd73609eea316d8fc6c13dc32ce6d35a266a111965cd342244f19911b77"
       ],
-      "text": "Everything is missing.",
+      "text": "Abrams is missing.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "08e15958aa21a4be897614f99ff07a615633adad39a580e7589abda2e4684213"
       ],
-      "text": "Everything's missing.",
+      "text": "Abrams is missing.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/wraith/ping/wraith_ping_atlas_missing_01.mp3.json
+++ b/transcripts/wraith/ping/wraith_ping_atlas_missing_01.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "08e15958aa21a4be897614f99ff07a615633adad39a580e7589abda2e4684213",
         "1b612fd73609eea316d8fc6c13dc32ce6d35a266a111965cd342244f19911b77"
-      ],
-      "text": "Abrams is missing.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "08e15958aa21a4be897614f99ff07a615633adad39a580e7589abda2e4684213"
       ],
       "text": "Abrams is missing.",
       "source": "generated",

--- a/transcripts/wrecker/ping/wrecker_ping_can_heal_sandeep.mp3.json
+++ b/transcripts/wrecker/ping/wrecker_ping_can_heal_sandeep.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "d3557fe2efedf4eb0f6bca40b584f09fc521f17f65aefc71908be760145b440b"
       ],
-      "text": "Sanddeep, I can hear you.",
+      "text": "Sandeep, I can heal you.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "a044f81abab00cae3b7d79ce8b57e2d6a35723a59ebccbf5df9a15f724b75de1"
       ],
-      "text": "Sandeep! I can heal you!",
+      "text": "Sandeep, I can heal you.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/wrecker/ping/wrecker_ping_can_heal_sandeep.mp3.json
+++ b/transcripts/wrecker/ping/wrecker_ping_can_heal_sandeep.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "a044f81abab00cae3b7d79ce8b57e2d6a35723a59ebccbf5df9a15f724b75de1",
         "d3557fe2efedf4eb0f6bca40b584f09fc521f17f65aefc71908be760145b440b"
-      ],
-      "text": "Sandeep, I can heal you.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "a044f81abab00cae3b7d79ce8b57e2d6a35723a59ebccbf5df9a15f724b75de1"
       ],
       "text": "Sandeep, I can heal you.",
       "source": "generated",

--- a/transcripts/wrecker/ping/wrecker_ping_fairfax_on_top_of_mid.mp3.json
+++ b/transcripts/wrecker/ping/wrecker_ping_fairfax_on_top_of_mid.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "b2c2f2cb21e4663fbe2dd8ef1acf835e19d84a17727b0554bf04bf4927eed5ea"
       ],
-      "text": "Deathbox on top of mid.",
+      "text": "Fairfax is on top of mid.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "cfcc584cffb48cff510f4540bcf1238d4ea6c23785541fe90a022a2a71488bbd"
       ],
-      "text": "Pocket's on top of mid!",
+      "text": "Fairfax is on top of mid.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/wrecker/ping/wrecker_ping_fairfax_on_top_of_mid.mp3.json
+++ b/transcripts/wrecker/ping/wrecker_ping_fairfax_on_top_of_mid.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "b2c2f2cb21e4663fbe2dd8ef1acf835e19d84a17727b0554bf04bf4927eed5ea"
-      ],
-      "text": "Fairfax is on top of mid.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "b2c2f2cb21e4663fbe2dd8ef1acf835e19d84a17727b0554bf04bf4927eed5ea",
         "cfcc584cffb48cff510f4540bcf1238d4ea6c23785541fe90a022a2a71488bbd"
       ],
       "text": "Fairfax is on top of mid.",

--- a/transcripts/wrecker/ping/wrecker_ping_gigawatt_under_garage.mp3.json
+++ b/transcripts/wrecker/ping/wrecker_ping_gigawatt_under_garage.mp3.json
@@ -4,14 +4,7 @@
   "revisions": [
     {
       "sha256": [
-        "00397ed5789b8e1ac4348218cbcd748561a3154bb3a514c7ff4bdd9fdede002d"
-      ],
-      "text": "Gigawatt's under the garage.",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
+        "00397ed5789b8e1ac4348218cbcd748561a3154bb3a514c7ff4bdd9fdede002d",
         "017daa63bba86e93cdf8f222bd1a67095d51ce58bafeba98c01c8ddf6c1bcf10"
       ],
       "text": "Gigawatt's under the garage.",

--- a/transcripts/wrecker/ping/wrecker_ping_gigawatt_under_garage.mp3.json
+++ b/transcripts/wrecker/ping/wrecker_ping_gigawatt_under_garage.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "00397ed5789b8e1ac4348218cbcd748561a3154bb3a514c7ff4bdd9fdede002d"
       ],
-      "text": "Get what's under the garage.",
+      "text": "Gigawatt's under the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "017daa63bba86e93cdf8f222bd1a67095d51ce58bafeba98c01c8ddf6c1bcf10"
       ],
-      "text": "Dig What's under the garage!",
+      "text": "Gigawatt's under the garage.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }

--- a/transcripts/wrecker/ping/wrecker_ping_krill_missing_01.mp3.json
+++ b/transcripts/wrecker/ping/wrecker_ping_krill_missing_01.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "e8405be1876a34659af45a4be904e44bbb08a3cb3782ba8eb660d1244287b489"
       ],
-      "text": "Trail is missing.",
+      "text": "Krill is missing.",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },

--- a/transcripts/wrecker/ping/wrecker_ping_see_sandeep_on_roof.mp3.json
+++ b/transcripts/wrecker/ping/wrecker_ping_see_sandeep_on_roof.mp3.json
@@ -4,15 +4,8 @@
   "revisions": [
     {
       "sha256": [
+        "0669b4bea092bec42e788e92fdab47a6356c6644f7e6be3065a5c08be3657e49",
         "1642e69449df6bd5b0313e1cbd91dcad21ec2cdbe195cdd71b4e61727d2138d5"
-      ],
-      "text": "Sandeep's on the roof!",
-      "source": "generated",
-      "model": "gpt-4o-mini-transcribe"
-    },
-    {
-      "sha256": [
-        "0669b4bea092bec42e788e92fdab47a6356c6644f7e6be3065a5c08be3657e49"
       ],
       "text": "Sandeep's on the roof!",
       "source": "generated",

--- a/transcripts/wrecker/ping/wrecker_ping_see_sandeep_on_roof.mp3.json
+++ b/transcripts/wrecker/ping/wrecker_ping_see_sandeep_on_roof.mp3.json
@@ -6,7 +6,7 @@
       "sha256": [
         "1642e69449df6bd5b0313e1cbd91dcad21ec2cdbe195cdd71b4e61727d2138d5"
       ],
-      "text": "Send it on the roof!",
+      "text": "Sandeep's on the roof!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     },
@@ -14,7 +14,7 @@
       "sha256": [
         "0669b4bea092bec42e788e92fdab47a6356c6644f7e6be3065a5c08be3657e49"
       ],
-      "text": "Mirage's on the roof.",
+      "text": "Sandeep's on the roof!",
       "source": "generated",
       "model": "gpt-4o-mini-transcribe"
     }


### PR DESCRIPTION
## Summary

- apply reviewed transcript corrections using recording SHA-256 hashes
- update every repository revision location associated with the 245 reviewed hashes
- consolidate equivalent same-file revisions and combine their SHA-256 values into one entry
- treat case, punctuation, and whitespace-only differences as equivalent, following the repository's transcript normalization rule

## Why

A review identified generated transcripts with obvious recognition errors, incorrect character or location names, punctuation issues, and leaked transcription prompts. Hash-based targeting ensures filename aliases and duplicate recording locations receive the same correction without changing unrelated recordings.

The corrections also caused multiple revisions in the same file to represent the same transcript. Keeping each equivalent transcript as one revision avoids redundant entries while retaining every associated recording hash.

## Impact

Updates 133 transcript files. The compaction pass merged 111 equivalent groups and removed 144 redundant revision entries while preserving all hashes and the repository's source/model precedence rules. No schema or tooling behavior changes.

## Validation

- `python -m unittest discover -s tests -v` (69 tests passed)
- `python -m tools.content_sync_cli validate --repo .` (`valid: true`, 0 errors, 0 warnings)
- verified no equivalent transcript groups remain in the changed files
- `git diff --check`